### PR TITLE
test(subprocess): assert ordering, not wall-clock, in the starved-pipe test

### DIFF
--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -215,7 +215,14 @@ describe("runSubprocess output capture", () => {
 			//
 			// existsSync is a synchronous syscall and yields nothing to the event
 			// loop, so the parent stays starved for the whole poll.
-			const spinDeadline = Date.now() + 30000;
+			//
+			// The deadline must stay well under vitest's 30s testTimeout
+			// (vitest.config.ts): if a real regression left the child blocked and
+			// the marker never appeared, the poll needs to exhaust and land on the
+			// expect(markerWrittenWhileStarved).toBe(true) failure below, not get
+			// killed by the framework's own timeout first, which would report an
+			// opaque hang instead of the actual assertion failure.
+			const spinDeadline = Date.now() + 20000;
 			let markerWrittenWhileStarved = false;
 			while (Date.now() < spinDeadline) {
 				if (existsSync(markerFile)) {

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -201,27 +201,15 @@ describe("runSubprocess output capture", () => {
 			// Starve the loop: the child runs and writes its full output during
 			// the spin, independent of whether the parent is draining anything.
 			//
-			// The invariant is ORDERING, not duration: the child must finish its
-			// whole 1MiB write while the parent is still starved and draining
-			// nothing. So spin until the marker appears rather than for a fixed
-			// stretch, and assert on the marker's existence. Comparing clock
-			// readings with a fixed cushion instead would encode an assumption
-			// about how fast a process spawns on an idle machine - a shared CI
-			// runner erases that cushion and reddens a test whose subject is
-			// perfectly healthy. The deadline is a generous upper bound that only
-			// trips on a real regression (a child actually blocked on the pipe
-			// never writes the marker at all), and the loop exits the moment the
-			// marker lands, so the normal path is fast.
+			// The invariant is ordering, not duration, so spin until the marker
+			// appears instead of for a fixed stretch: a child genuinely blocked
+			// on the pipe never writes the marker, so exhausting the deadline is
+			// the regression signal, and the healthy path exits immediately.
 			//
-			// existsSync is a synchronous syscall and yields nothing to the event
-			// loop, so the parent stays starved for the whole poll.
-			//
-			// The deadline must stay well under vitest's 30s testTimeout
-			// (vitest.config.ts): if a real regression left the child blocked and
-			// the marker never appeared, the poll needs to exhaust and land on the
-			// expect(markerWrittenWhileStarved).toBe(true) failure below, not get
-			// killed by the framework's own timeout first, which would report an
-			// opaque hang instead of the actual assertion failure.
+			// existsSync is a synchronous syscall, so the loop never yields and
+			// the parent stays starved for the whole poll. The deadline must stay
+			// well under vitest's 30s testTimeout so a regression lands on the
+			// assertion below rather than an opaque framework timeout.
 			const spinDeadline = Date.now() + 20000;
 			let markerWrittenWhileStarved = false;
 			while (Date.now() < spinDeadline) {

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -200,24 +200,34 @@ describe("runSubprocess output capture", () => {
 
 			// Starve the loop: the child runs and writes its full output during
 			// the spin, independent of whether the parent is draining anything.
-			const spinUntil = Date.now() + 2000;
-			while (Date.now() < spinUntil) {
-				// Busy-wait: simulates a synchronous engine pass starving the loop.
+			//
+			// The invariant is ORDERING, not duration: the child must finish its
+			// whole 1MiB write while the parent is still starved and draining
+			// nothing. So spin until the marker appears rather than for a fixed
+			// stretch, and assert on the marker's existence. Comparing clock
+			// readings with a fixed cushion instead would encode an assumption
+			// about how fast a process spawns on an idle machine - a shared CI
+			// runner erases that cushion and reddens a test whose subject is
+			// perfectly healthy. The deadline is a generous upper bound that only
+			// trips on a real regression (a child actually blocked on the pipe
+			// never writes the marker at all), and the loop exits the moment the
+			// marker lands, so the normal path is fast.
+			//
+			// existsSync is a synchronous syscall and yields nothing to the event
+			// loop, so the parent stays starved for the whole poll.
+			const spinDeadline = Date.now() + 30000;
+			let markerWrittenWhileStarved = false;
+			while (Date.now() < spinDeadline) {
+				if (existsSync(markerFile)) {
+					markerWrittenWhileStarved = true;
+					break;
+				}
 			}
-			const spinEnd = Date.now();
 
 			const result = await promise;
 
 			expect(result.stdout.length).toBe(1048576);
-
-			const markerTimestamp = Number(readFileSync(markerFile, "utf-8"));
-			// A pipe-blocked child cannot write the marker until the parent
-			// drains after the spin, so any margin before spinEnd proves the
-			// child finished while the parent was still starved. Keep the
-			// margin small: the old 1500ms version budgeted only 500ms for
-			// child spawn plus write, which loaded Windows CI runners
-			// repeatedly overshot by tens of milliseconds.
-			expect(markerTimestamp).toBeLessThan(spinEnd - 250);
+			expect(markerWrittenWhileStarved).toBe(true);
 		} finally {
 			rmSync(markerFile, { force: true });
 		}


### PR DESCRIPTION
Replaces a wall-clock assertion in the starved-pipe backpressure test with an ordering-based one. The old test required the child to finish writing its full 1MiB output within the first 500ms of a fixed 2000ms busy-spin; under CI load that cushion evaporates and the test reddens even though the subject (capturing subprocess output via temp files instead of pipes) is healthy.

The test's actual invariant is that the child finishes its write while the parent is still starved, not that it finishes within some fixed duration. The fix polls existsSync(markerFile) inside the busy loop up to a generous 30s deadline and asserts on that boolean instead of comparing timestamps: a genuinely pipe-blocked child never writes the marker at all, so real regressions still fail, and the loop exits the moment the marker lands so the healthy path stays fast.

Verified: pnpm typecheck clean, pnpm vitest run tests/subprocess.test.ts 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
