### PR TITLE
fix(ai-slop): recognize logger.exception as capturing the error in silent-recovery

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -198,7 +198,7 @@ The rules that make aislop unique. These catch the patterns AI assistants leave 
 | `ai-slop/trivial-comment` | warning | Comments restating the code (`// Import React`, `// Return the value`) |
 | `ai-slop/narrative-comment` | warning | Decorative separators, phase/section headers, JSDoc preambles without meaningful tags (caught on top-level *and* interface/type members), cross-reference commentary, and longer prose blocks that carry an AI-narration signal (a restatement opener or step-by-step narration). Length alone is not flagged. |
 | `ai-slop/swallowed-exception` | error | Empty catch blocks, catch blocks that only log (JS/TS/Python/Go/Ruby/Java/C#) |
-| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue. Python except-blocks are exempt when a log line calls `logger.exception(...)` or passes `exc_info=True`, since both attach the traceback; the exemption is cancelled when that same line spells `exc_info=False`. Any other `exc_info` value (a variable, an expression) stays exempt rather than guessed at. |
+| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue; Python logging calls that attach the traceback are exempt (see notes below the table) |
 | `ai-slop/meta-comment` | warning | Comments about implementation phases, agent behavior, or generated-code process instead of the code itself |
 | `ai-slop/hidden-fallback` | warning | JS/TS fallback logic that turns missing counts, failed diagnostics, or impossible states into safe-looking values without surfacing the missing input or failure |
 | `ai-slop/redundant-try-catch` | warning | JS/TS catch blocks that only rethrow the same error without adding context, cleanup, or recovery |
@@ -279,6 +279,15 @@ its line, making the string a bare expression statement - PEP 257
 first-statement docstrings, attribute docstrings, and block-comment strings,
 including the single-line form. An assigned or call-wrapped triple-quoted
 value is a runtime value and stays scanned.
+
+**`ai-slop/silent-recovery` and Python traceback-attaching logs.** A Python
+except-block is exempt when a log line calls `logger.exception(...)` or passes
+`exc_info=True`, since both attach the currently-handled exception's traceback
+even though no bound exception name appears in the call. The exemption is
+cancelled when that same line spells the literal `exc_info=False`, which
+Python forwards to `Logger.error`, omitting the traceback. Any other
+`exc_info` value (a variable, an expression) stays exempt rather than guessed
+at, since deciding its value would mean evaluating Python.
 
 ## Security
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -198,7 +198,7 @@ The rules that make aislop unique. These catch the patterns AI assistants leave 
 | `ai-slop/trivial-comment` | warning | Comments restating the code (`// Import React`, `// Return the value`) |
 | `ai-slop/narrative-comment` | warning | Decorative separators, phase/section headers, JSDoc preambles without meaningful tags (caught on top-level *and* interface/type members), cross-reference commentary, and longer prose blocks that carry an AI-narration signal (a restatement opener or step-by-step narration). Length alone is not flagged. |
 | `ai-slop/swallowed-exception` | error | Empty catch blocks, catch blocks that only log (JS/TS/Python/Go/Ruby/Java/C#) |
-| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue |
+| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue. Python except-blocks are exempt when a log line calls `logger.exception(...)` or passes `exc_info=True`, since both attach the traceback; the exemption is cancelled when that same line spells `exc_info=False`. Any other `exc_info` value (a variable, an expression) stays exempt rather than guessed at. |
 | `ai-slop/meta-comment` | warning | Comments about implementation phases, agent behavior, or generated-code process instead of the code itself |
 | `ai-slop/hidden-fallback` | warning | JS/TS fallback logic that turns missing counts, failed diagnostics, or impossible states into safe-looking values without surfacing the missing input or failure |
 | `ai-slop/redundant-try-catch` | warning | JS/TS catch blocks that only rethrow the same error without adding context, cleanup, or recovery |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -198,7 +198,7 @@ The rules that make aislop unique. These catch the patterns AI assistants leave 
 | `ai-slop/trivial-comment` | warning | Comments restating the code (`// Import React`, `// Return the value`) |
 | `ai-slop/narrative-comment` | warning | Decorative separators, phase/section headers, JSDoc preambles without meaningful tags (caught on top-level *and* interface/type members), cross-reference commentary, and longer prose blocks that carry an AI-narration signal (a restatement opener or step-by-step narration). Length alone is not flagged. |
 | `ai-slop/swallowed-exception` | error | Empty catch blocks, catch blocks that only log (JS/TS/Python/Go/Ruby/Java/C#) |
-| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue. Python except-blocks are exempt when a log line calls `logger.exception(...)` or passes `exc_info=True`, since both attach the traceback; the exemption is cancelled when that same line spells `exc_info=False`. Any other `exc_info` value (a variable, an expression) stays exempt rather than guessed at. |
+| `ai-slop/silent-recovery` | warning | Catch blocks that log without including the caught error and then continue; Python logging calls that attach the traceback are exempt (see notes below the table) |
 | `ai-slop/meta-comment` | warning | Comments about implementation phases, agent behavior, or generated-code process instead of the code itself |
 | `ai-slop/hidden-fallback` | warning | JS/TS fallback logic that turns missing counts, failed diagnostics, or impossible states into safe-looking values without surfacing the missing input or failure |
 | `ai-slop/redundant-try-catch` | warning | JS/TS catch blocks that only rethrow the same error without adding context, cleanup, or recovery |
@@ -255,6 +255,17 @@ The rules that make aislop unique. These catch the patterns AI assistants leave 
 | `ai-slop/cpp-endl-in-stream` | warning | `<< std::endl` flushes the stream on every call; prefer `'\n'` |
 
 Note: `ai-slop/trivial-comment`, `ai-slop/narrative-comment`, and `ai-slop/swallowed-exception` also cover C# (`.cs`) and C/C++ (`.c`, `.cpp`, `.h`, `.hpp`).
+
+### Rule notes
+
+**`ai-slop/silent-recovery` and Python traceback-attaching logs.** A Python
+except-block is exempt when a log line calls `logger.exception(...)` or passes
+`exc_info=True`, since both attach the currently-handled exception's traceback
+even though no bound exception name appears in the call. The exemption is
+cancelled when that same line spells the literal `exc_info=False`, which
+Python forwards to `Logger.error`, omitting the traceback. Any other
+`exc_info` value (a variable, an expression) stays exempt rather than guessed
+at, since deciding its value would mean evaluating Python.
 
 ## Security
 

--- a/src/engines/ai-slop/silent-recovery.ts
+++ b/src/engines/ai-slop/silent-recovery.ts
@@ -111,11 +111,19 @@ const PY_EXCEPT_BINDING_RE = /\bas\s+(\w+)\s*:/;
 const PY_LOG_STATEMENT_RE =
 	/^(?:logging|logger|log|self\.log|self\.logger|print)(?:\.(?:debug|info|warning|warn|error|exception|critical))?\s*\(/;
 const PY_HANDLING_TOKEN_RE = /^(?:raise\b|return\b|continue\b|break\b|self\.|[\w.]+\s*=)/;
-// `logging.Logger.exception(...)` always attaches the currently-handled exception's
-// traceback (it is exactly `.error(..., exc_info=True)`), and `exc_info=True` on any
+// `logging.Logger.exception(...)` defaults to attaching the currently-handled
+// exception's traceback (it is `.error(..., exc_info=True)`), and `exc_info=True` on any
 // logging call does the same explicitly. Either one means the failure cause is
 // captured even though no `except ... as <name>` identifier appears in the log call.
 const PY_LOG_CAPTURES_EXCEPTION_RE = /\.exception\s*\(|\bexc_info\s*=\s*True\b/;
+// `.exception(..., exc_info=False)` forwards that value to `Logger.error` and drops the
+// traceback, so the literal spelling on the same line cancels the exemption. Only the
+// literal `False` is recognized; an `exc_info` set to anything else stays exempt rather
+// than guessed at.
+const PY_EXC_INFO_DISABLED_RE = /\bexc_info\s*=\s*False\b/;
+
+const pyLogLineCapturesException = (line: string): boolean =>
+	PY_LOG_CAPTURES_EXCEPTION_RE.test(line) && !PY_EXC_INFO_DISABLED_RE.test(line);
 
 const detectPySilentRecovery = (content: string, relPath: string): Diagnostic[] => {
 	const out: Diagnostic[] = [];
@@ -145,7 +153,7 @@ const detectPySilentRecovery = (content: string, relPath: string): Diagnostic[] 
 		);
 		const sawLog = bodyLines.some((line) => PY_LOG_STATEMENT_RE.test(line));
 		if (!allLogs || !sawLog) continue;
-		if (bodyLines.some((line) => PY_LOG_CAPTURES_EXCEPTION_RE.test(line))) continue;
+		if (bodyLines.some(pyLogLineCapturesException)) continue;
 		if (!recoveryDropsError(PY_EXCEPT_BINDING_RE.exec(lines[i])?.[1], bodyLines.join(" ")))
 			continue;
 

--- a/src/engines/ai-slop/silent-recovery.ts
+++ b/src/engines/ai-slop/silent-recovery.ts
@@ -111,6 +111,11 @@ const PY_EXCEPT_BINDING_RE = /\bas\s+(\w+)\s*:/;
 const PY_LOG_STATEMENT_RE =
 	/^(?:logging|logger|log|self\.log|self\.logger|print)(?:\.(?:debug|info|warning|warn|error|exception|critical))?\s*\(/;
 const PY_HANDLING_TOKEN_RE = /^(?:raise\b|return\b|continue\b|break\b|self\.|[\w.]+\s*=)/;
+// `logging.Logger.exception(...)` always attaches the currently-handled exception's
+// traceback (it is exactly `.error(..., exc_info=True)`), and `exc_info=True` on any
+// logging call does the same explicitly. Either one means the failure cause is
+// captured even though no `except ... as <name>` identifier appears in the log call.
+const PY_LOG_CAPTURES_EXCEPTION_RE = /\.exception\s*\(|\bexc_info\s*=\s*True\b/;
 
 const detectPySilentRecovery = (content: string, relPath: string): Diagnostic[] => {
 	const out: Diagnostic[] = [];
@@ -140,6 +145,7 @@ const detectPySilentRecovery = (content: string, relPath: string): Diagnostic[] 
 		);
 		const sawLog = bodyLines.some((line) => PY_LOG_STATEMENT_RE.test(line));
 		if (!allLogs || !sawLog) continue;
+		if (bodyLines.some((line) => PY_LOG_CAPTURES_EXCEPTION_RE.test(line))) continue;
 		if (!recoveryDropsError(PY_EXCEPT_BINDING_RE.exec(lines[i])?.[1], bodyLines.join(" ")))
 			continue;
 

--- a/tests/silent-recovery.test.ts
+++ b/tests/silent-recovery.test.ts
@@ -267,4 +267,49 @@ describe("silent-recovery (Python)", () => {
 		);
 		expect(await silentRecoveryDiags()).toHaveLength(0);
 	});
+
+	it("does NOT flag a bare except with logger.exception (traceback is captured automatically)", async () => {
+		writeFile(
+			"src/e.py",
+			[
+				"def run_benchmark():",
+				"    try:",
+				"        execute()",
+				"    except Exception:",
+				"        logger.exception('bench run failed')",
+				"",
+			].join("\n"),
+		);
+		expect(await silentRecoveryDiags()).toHaveLength(0);
+	});
+
+	it("does NOT flag except-as-e with logger.exception even when the binding is unused in the log call", async () => {
+		writeFile(
+			"src/f.py",
+			[
+				"def run_benchmark(run_id):",
+				"    try:",
+				"        execute()",
+				"    except Exception as e:",
+				"        logger.exception('benchmark run %s crashed', run_id)",
+				"",
+			].join("\n"),
+		);
+		expect(await silentRecoveryDiags()).toHaveLength(0);
+	});
+
+	it("does NOT flag except that logs with exc_info=True (traceback attached explicitly)", async () => {
+		writeFile(
+			"src/g.py",
+			[
+				"def run_benchmark():",
+				"    try:",
+				"        execute()",
+				"    except Exception:",
+				"        logger.error('bench run failed', exc_info=True)",
+				"",
+			].join("\n"),
+		);
+		expect(await silentRecoveryDiags()).toHaveLength(0);
+	});
 });

--- a/tests/silent-recovery.test.ts
+++ b/tests/silent-recovery.test.ts
@@ -312,4 +312,51 @@ describe("silent-recovery (Python)", () => {
 		);
 		expect(await silentRecoveryDiags()).toHaveLength(0);
 	});
+
+	it("flags except that logs with logger.exception(..., exc_info=False) (traceback suppressed)", async () => {
+		writeFile(
+			"src/h.py",
+			[
+				"def run_benchmark():",
+				"    try:",
+				"        execute()",
+				"    except Exception:",
+				"        logger.exception('bench run failed', exc_info=False)",
+				"",
+			].join("\n"),
+		);
+		const diags = await silentRecoveryDiags();
+		expect(diags).toHaveLength(1);
+		expect(diags[0].line).toBe(4);
+	});
+
+	it("flags except-as-e whose logger.exception spells exc_info = False with spaces", async () => {
+		writeFile(
+			"src/i.py",
+			[
+				"def run_benchmark(run_id):",
+				"    try:",
+				"        execute()",
+				"    except Exception as e:",
+				"        logger.exception('benchmark run %s crashed', run_id, exc_info = False)",
+				"",
+			].join("\n"),
+		);
+		expect(await silentRecoveryDiags()).toHaveLength(1);
+	});
+
+	it("does NOT flag logger.exception with a non-literal exc_info value (deliberate non-detection)", async () => {
+		writeFile(
+			"src/j.py",
+			[
+				"def run_benchmark(verbose):",
+				"    try:",
+				"        execute()",
+				"    except Exception:",
+				"        logger.exception('bench run failed', exc_info=verbose)",
+				"",
+			].join("\n"),
+		);
+		expect(await silentRecoveryDiags()).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
Fixes a false positive in the ai-slop/silent-recovery Python detector: except-blocks that log via `logger.exception(...)` or `logger.error(..., exc_info=True)` were being flagged as silently dropping the caught exception, even though both forms attach the full traceback. The detector now recognizes either pattern as capturing the error and skips the flag.

One review-driven bound: an explicit `exc_info=False` on the same line cancels the exemption, since Python forwards that value to `Logger.error` and the traceback is omitted. Any other `exc_info` value (a variable, an expression) stays exempt rather than guessed at, and docs/rules.md records the bound.

Test plan:
- pnpm typecheck clean
- tests/silent-recovery.test.ts 20/20 pass (6 new cases: bare except + logger.exception, except-as-e with unused binding, logger.error with exc_info=True, exc_info=False with and without whitespace around the `=`, and the pinned exc_info-bound-to-a-variable non-detection)
- Each new test was confirmed to fail without its source fix
- Full suite after build: 2024 passed / 14 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
