### PR TITLE
fix(doctor): derive languages from source files, not manifests alone

### DIFF
--- a/src/commands/doctor-plan.ts
+++ b/src/commands/doctor-plan.ts
@@ -32,6 +32,8 @@ export interface ToolDecision {
 
 const primaryLanguage = (langs: Language[]): Language | null => {
 	// Prefer explicit ordering: JS/TS -> Python -> Go -> Rust -> Ruby -> PHP -> Java
+	// -> C# -> C/C++. Every language has to appear here or a mixed project falls
+	// through to the bare "mixed" label with no headline language.
 	const order: Language[] = [
 		"typescript",
 		"javascript",
@@ -41,6 +43,8 @@ const primaryLanguage = (langs: Language[]): Language | null => {
 		"ruby",
 		"php",
 		"java",
+		"csharp",
+		"cpp",
 	];
 	for (const lang of order) {
 		if (langs.includes(lang)) return lang;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,7 +10,8 @@ import {
 import { renderHeader } from "../ui/header.js";
 import { detectInvocation } from "../ui/invocation.js";
 import { style, theme } from "../ui/theme.js";
-import { discoverProject } from "../utils/discover.js";
+import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
+import { getSourceFilesForRoot } from "../utils/source-files.js";
 import { APP_VERSION } from "../version.js";
 import { buildRows, type DoctorEngineRow, languageLabelFor } from "./doctor-plan.js";
 
@@ -101,7 +102,19 @@ export const doctorCommand = async (
 	options: DoctorOptions = {},
 ): Promise<void> => {
 	const resolvedDir = path.resolve(directory);
-	const projectInfo = await discoverProject(resolvedDir);
+	const sourceFiles = getSourceFilesForRoot(resolvedDir);
+	const discoveredProject = await discoverProject(resolvedDir, [], { sourceFiles });
+	// scan plans its engines from the languages of the files it will actually read,
+	// so doctor has to as well or it promises tooling scan never runs. A manifest can
+	// name a language the tree does not contain: a root package.json that exists only
+	// to pin a CLI tool makes a C# or C++ repository look like a JavaScript one, and
+	// the JS-gated planners then claim every engine. Manifest languages remain the
+	// answer for a project with no source files yet.
+	const sourceLanguages = detectSourceLanguages(sourceFiles);
+	const projectInfo =
+		sourceLanguages.length > 0
+			? { ...discoveredProject, languages: sourceLanguages }
+			: discoveredProject;
 	const config = loadConfig(resolvedDir);
 
 	const rows = buildRows({ rootDirectory: resolvedDir, projectInfo, config });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -11,9 +11,11 @@ import { renderHeader } from "../ui/header.js";
 import { detectInvocation } from "../ui/invocation.js";
 import { style, theme } from "../ui/theme.js";
 import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
-import { getSourceFilesForRoot } from "../utils/source-files.js";
+import { resetGitIgnoreSnapshots } from "../utils/git-ignore.js";
+import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { APP_VERSION } from "../version.js";
 import { buildRows, type DoctorEngineRow, languageLabelFor } from "./doctor-plan.js";
+import { collectScanFileScope } from "./scan-file-scope.js";
 
 export type { DoctorEngineRow } from "./doctor-plan.js";
 export { planFormatForTest, planLintForTest, planSecurityForTest } from "./doctor-plan.js";
@@ -102,20 +104,36 @@ export const doctorCommand = async (
 	options: DoctorOptions = {},
 ): Promise<void> => {
 	const resolvedDir = path.resolve(directory);
-	const sourceFiles = getSourceFilesForRoot(resolvedDir);
-	const discoveredProject = await discoverProject(resolvedDir, [], { sourceFiles });
+	const config = loadConfig(resolvedDir);
+	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
+	// discoverProject resets the cached gitignore snapshot, but the scan scope below is
+	// enumerated before it runs, so reset here first: the enumeration must not answer
+	// from a snapshot an earlier call left behind, and the interactive loop and the MCP
+	// server both keep one process alive across calls.
+	resetGitIgnoreSnapshots();
+	const scanScope = collectScanFileScope({
+		excludePatterns,
+		includePatterns: config.include,
+		mode: { kind: "full" },
+		rootDirectory: resolvedDir,
+	});
+	const discoveredProject = await discoverProject(resolvedDir, excludePatterns, {
+		includePatterns: config.include,
+		sourceFiles: scanScope.files,
+	});
 	// scan plans its engines from the languages of the files it will actually read,
 	// so doctor has to as well or it promises tooling scan never runs. A manifest can
 	// name a language the tree does not contain: a root package.json that exists only
 	// to pin a CLI tool makes a C# or C++ repository look like a JavaScript one, and
-	// the JS-gated planners then claim every engine. Manifest languages remain the
-	// answer for a project with no source files yet.
-	const sourceLanguages = detectSourceLanguages(sourceFiles);
+	// the JS-gated planners then claim every engine. Reading the same full-scan scope
+	// keeps the two commands in step over config.include, config.exclude, .aislopignore
+	// and test files, any one of which otherwise moves a language between them.
+	// Manifest languages remain the answer for a project with no source files yet.
+	const sourceLanguages = detectSourceLanguages([...scanScope.files, ...scanScope.testFiles]);
 	const projectInfo =
 		sourceLanguages.length > 0
 			? { ...discoveredProject, languages: sourceLanguages }
 			: discoveredProject;
-	const config = loadConfig(resolvedDir);
 
 	const rows = buildRows({ rootDirectory: resolvedDir, projectInfo, config });
 

--- a/tests/commands/doctor.languages.test.ts
+++ b/tests/commands/doctor.languages.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { doctorCommand } from "../../src/commands/doctor.js";
+import { stripAnsi } from "../helpers/ansi.js";
+
+let projectDir: string;
+
+const writeProjectFile = (relativePath: string, content: string): void => {
+	const target = path.join(projectDir, relativePath);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, content, "utf-8");
+};
+
+// A root package.json that pins a CLI tool but ships no JavaScript. This is the
+// shape that made doctor call a C# repository a JavaScript one.
+const writeToolPinManifest = (): void => {
+	writeProjectFile(
+		"package.json",
+		`${JSON.stringify({ name: "tool-pin", devDependencies: { aislop: "0.11.0" } }, null, 2)}\n`,
+	);
+};
+
+const writeCsharpProject = (): void => {
+	writeProjectFile("src/App.csproj", "<Project></Project>\n");
+	writeProjectFile("src/Program.cs", "class Program { static void Main() { } }\n");
+};
+
+const runDoctor = async (): Promise<string> => {
+	vi.mocked(process.stdout.write).mockClear();
+	await doctorCommand(projectDir, { printBrand: false });
+	return stripAnsi(
+		vi
+			.mocked(process.stdout.write)
+			.mock.calls.map(([chunk]) => String(chunk))
+			.join(""),
+	);
+};
+
+beforeEach(() => {
+	projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-doctor-languages-"));
+	// Source-file enumeration walks the git index, so the fixture needs a repo.
+	execFileSync("git", ["init", "-q"], { cwd: projectDir });
+	vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("doctor language detection", () => {
+	it("reports csharp for a C# project whose root package.json only pins a CLI tool", async () => {
+		writeToolPinManifest();
+		writeCsharpProject();
+
+		const out = await runDoctor();
+
+		expect(out).toContain("csharp");
+		expect(out).not.toContain("javascript");
+		expect(out).not.toContain("biome");
+		expect(out).not.toContain("oxlint");
+		expect(out).not.toContain("knip");
+	});
+
+	it("plans the C# tools for a tool-pinned C# project when project evaluation is on", async () => {
+		writeToolPinManifest();
+		writeCsharpProject();
+		writeProjectFile(".aislop/config.yml", "lint:\n  csharp:\n    projectEvaluation: true\n");
+
+		const out = await runDoctor();
+
+		expect(out).toContain("dotnet format whitespace");
+		expect(out).toMatch(/jb inspectcode|roslynator/);
+	});
+
+	it("keeps the manifest language for a project with no source files yet", async () => {
+		writeToolPinManifest();
+
+		const out = await runDoctor();
+
+		expect(out).toContain("javascript");
+		expect(out).toContain("biome (bundled)");
+	});
+});

--- a/tests/commands/doctor.languages.test.ts
+++ b/tests/commands/doctor.languages.test.ts
@@ -84,4 +84,58 @@ describe("doctor language detection", () => {
 		expect(out).toContain("javascript");
 		expect(out).toContain("biome (bundled)");
 	});
+
+	it("ignores a JavaScript subtree the config excludes", async () => {
+		writeCsharpProject();
+		writeProjectFile("legacy/app.js", "module.exports = {};\n");
+		writeProjectFile(".aislop/config.yml", "exclude:\n  - legacy/**\n");
+
+		const out = await runDoctor();
+
+		expect(out).toContain("csharp");
+		expect(out).not.toContain("javascript");
+		expect(out).not.toContain("biome");
+		expect(out).not.toContain("oxlint");
+	});
+
+	it("ignores a JavaScript subtree .aislopignore excludes", async () => {
+		writeCsharpProject();
+		writeProjectFile("legacy/app.js", "module.exports = {};\n");
+		writeProjectFile(".aislopignore", "legacy/\n");
+
+		const out = await runDoctor();
+
+		expect(out).toContain("csharp");
+		expect(out).not.toContain("javascript");
+		expect(out).not.toContain("biome");
+		expect(out).not.toContain("oxlint");
+	});
+
+	// The gitignore snapshot is cached per root and only discarded at the start of a
+	// run, so a long-lived caller (the interactive loop, the MCP server) classifies
+	// the second run's files against it. Enumerating before the reset made a file
+	// added between the two runs read as ignored.
+	it("sees a source file added between two runs in the same process", async () => {
+		writeToolPinManifest();
+		await runDoctor();
+
+		writeCsharpProject();
+		const out = await runDoctor();
+
+		expect(out).toContain("csharp");
+	});
+
+	// scan derives its languages from source and test files alike, so a C# project
+	// whose only JavaScript is its tests still gets the JS tools there. doctor has
+	// to name them or it reports tooling scan does not run.
+	it("reports javascript for a C# project whose only JavaScript is its tests", async () => {
+		writeCsharpProject();
+		writeProjectFile("tests/app.test.js", "test('works', () => {});\n");
+
+		const out = await runDoctor();
+
+		expect(out).toContain("javascript");
+		expect(out).toContain("biome (bundled)");
+		expect(out).toContain("oxlint (bundled)");
+	});
 });


### PR DESCRIPTION
`aislop doctor` planned engines from the languages a project's manifests name rather than the languages its source files are written in. A repository whose root package.json exists only to pin a CLI tool reported as "javascript (mixed)" and planned biome, oxlint, and knip - with no C# or C++ engine in the plan at all - even though `aislop scan` on the same tree correctly detected csharp and ran clang-tidy, cppcheck, and jb.

This completes the direction of #258, which moved scan to source-file-derived languages but left doctor consuming manifest languages verbatim. scan avoids this by overriding the discovered languages with detectSourceLanguages over the files it will actually read; doctor now derives its language view from that same scope: it loads the config first and reads collectScanFileScope in full mode (source and test files alike, with config.include, config.exclude, and .aislopignore applied), passes the scope's files into discoverProject so the tree is not walked twice, and keeps manifest languages only when the tree has no source files yet. The cached gitignore snapshot is reset before that enumeration, so a long-lived consumer of the exported doctorCommand (the interactive loop, the MCP server) does not classify files added since a previous call against a stale snapshot. So the doctor report now matches what a scan will actually do. primaryLanguage also gains the csharp and cpp entries it was never given, which otherwise leave a mixed C#/C++ project labeled just "mixed".

The alternative of fixing detectLanguages centrally (dropping uncorroborated manifest languages) was rejected: discoverProject's languages also drive dependency-audit selection, so a tooling-pin repository would silently lose its npm/pnpm audit, and an existing test asserts package.json alone implies javascript for that purpose.

Regression tests: the tooling-pin package.json at root + C# source in a subdirectory fails before the fix with the exact reported symptom and passes after; a guard test confirms a manifest-only project still reports javascript; review-round tests cover a config-excluded and an .aislopignore-excluded JavaScript subtree, a C# project whose only JavaScript is its tests, and two doctorCommand calls in one process with a source file added between them (each confirmed to fail without its source fix). Full suite 2025 passed / 14 skipped / 0 failed; self-scan 100/100. Smoke-tested against the real-world reproducing repository: doctor now reports "csharp (mixed)" with dotnet format and jb inspectcode planned, and the lockfile-driven npm audit row is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
