### PR TITLE
feat(fix): add --dry-run preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The deterministic layer beneath [`aislop agent`](#run-a-local-repair-agent): aut
 
 ```bash
 aislop fix                 # auto-fixes
+aislop fix --dry-run       # preview planned steps without writing files
 aislop fix -d              # detailed fix progress
 aislop fix --safe          # only reversible fixes (imports, comment removal, safe formatters)
 aislop fix -f              # aggressive: deps, unused files

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -90,6 +90,7 @@ Use `--changes --base origin/<target>` to gate a pull request on only the files 
 | `-d, --verbose` | Show detailed fix progress |
 | `-f, --force` | Run aggressive fixes: dependency audit, framework alignment, unused file removal |
 | `--safe` | Only apply reversible fixes |
+| `--dry-run` | Print planned fix steps, eligible findings, and skipped steps without writing files |
 | `-p, --prompt` | Print an agent-ready prompt for remaining issues |
 
 Agent handoff flags: `--claude`, `--codex`, `--cursor`, `--windsurf`, `--vscode`, `--amp`, `--antigravity`, `--deep-agents`, `--gemini`, `--kimi`, `--opencode`, `--warp`, `--aider`, `--goose`, `--pi`, `--crush`.
@@ -247,6 +248,7 @@ aislop scan --sarif
 
 # Fix
 aislop fix
+aislop fix --dry-run
 aislop fix --safe
 aislop fix -f
 aislop fix --claude

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,7 @@ const fixProgram = program
 		"--safe",
 		"only apply reversible fixes (imports, comment removal, safe formatters); skip anything that deletes code, rewrites behaviour, or runs unsafe formatter configs",
 	)
+	.option("--dry-run", "print planned fix steps without writing files")
 	.option("-p, --prompt", "print a prompt for your coding agent to fix remaining issues");
 
 for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
@@ -138,6 +139,7 @@ fixProgram.action(async (directory = ".", _flags, command) => {
 		verbose: Boolean(flags.verbose),
 		force: Boolean(flags.force),
 		safe: Boolean(flags.safe),
+		dryRun: Boolean(flags.dryRun),
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});

--- a/src/commands/fix-plan.ts
+++ b/src/commands/fix-plan.ts
@@ -118,6 +118,17 @@ const planFormatters = (
 		projectInfo.languages.includes("php") && Boolean(projectInfo.installedTools["php-cs-fixer"]),
 		safe ? SKIPPED_BY_SAFE : undefined,
 	);
+	add(
+		"Formatting (csharp)",
+		projectInfo.languages.includes("csharp") &&
+			Boolean(projectInfo.installedTools.dotnet) &&
+			config.lint?.csharp?.projectEvaluation === true,
+	);
+	add(
+		"Formatting (cpp)",
+		projectInfo.languages.includes("cpp") &&
+			Boolean(projectInfo.installedTools["clang-format"]),
+	);
 	return steps;
 };
 

--- a/src/commands/fix-plan.ts
+++ b/src/commands/fix-plan.ts
@@ -1,72 +1,182 @@
 import type { AislopConfig } from "../config/index.js";
 import type { ProjectInfo } from "../utils/discover.js";
 
-interface FixStepPlanOptions {
-	force?: boolean;
+export interface FixPlanStep {
+	name: string;
+	status: "planned" | "skipped";
+	reason?: string;
 }
+
+export interface FixPlanOptions {
+	force?: boolean;
+	safe?: boolean;
+}
+
+const SKIPPED_BY_SAFE = "skipped by --safe";
+const DISABLED_IN_CONFIG = "disabled in config";
 
 const hasJsTs = (projectInfo: ProjectInfo): boolean =>
 	projectInfo.languages.includes("typescript") || projectInfo.languages.includes("javascript");
 
+const planned = (name: string): FixPlanStep => ({ name, status: "planned" });
+
+const skipped = (name: string, reason: string): FixPlanStep => ({
+	name,
+	status: "skipped",
+	reason,
+});
+
+const gated = (name: string, enabled: boolean, reason: string): FixPlanStep =>
+	enabled ? planned(name) : skipped(name, reason);
+
+const planAiSlop = (config: AislopConfig, safe: boolean): FixPlanStep[] => {
+	if (!config.engines["ai-slop"]) {
+		const names = safe
+			? ["Unused imports", "Duplicate imports", "Narrative comments"]
+			: ["Unused imports", "Duplicate imports", "Dead code & comments"];
+		return names.map((name) => skipped(name, DISABLED_IN_CONFIG));
+	}
+	if (safe) {
+		return [
+			planned("Unused imports"),
+			planned("Duplicate imports"),
+			planned("Narrative comments"),
+			skipped("Dead code & comments", SKIPPED_BY_SAFE),
+		];
+	}
+	return [planned("Unused imports"), planned("Duplicate imports"), planned("Dead code & comments")];
+};
+
+const planQualityStep = (
+	name: string,
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	safe: boolean,
+): FixPlanStep[] => {
+	if (!hasJsTs(projectInfo)) return [];
+	const qualityOn = config.engines["code-quality"];
+	const reason = safe ? SKIPPED_BY_SAFE : qualityOn ? "" : DISABLED_IN_CONFIG;
+	return [reason ? skipped(name, reason) : planned(name)];
+};
+
+const planLint = (projectInfo: ProjectInfo, config: AislopConfig, safe: boolean): FixPlanStep[] => {
+	const steps: FixPlanStep[] = [];
+	const reason = safe ? SKIPPED_BY_SAFE : config.engines.lint ? "" : DISABLED_IN_CONFIG;
+	if (hasJsTs(projectInfo)) {
+		steps.push(reason ? skipped("Lint fixes (js/ts)", reason) : planned("Lint fixes (js/ts)"));
+	}
+	if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
+		steps.push(reason ? skipped("Lint fixes (python)", reason) : planned("Lint fixes (python)"));
+	}
+	if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
+		steps.push(reason ? skipped("Lint fixes (ruby)", reason) : planned("Lint fixes (ruby)"));
+	}
+	return steps;
+};
+
+const planFormatters = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	safe: boolean,
+): FixPlanStep[] => {
+	const steps: FixPlanStep[] = [];
+	const formatOn = config.engines.format;
+	const engineReason = formatOn ? "" : DISABLED_IN_CONFIG;
+	const add = (name: string, eligible: boolean, extraReason?: string) => {
+		if (!eligible) return;
+		if (engineReason) {
+			steps.push(skipped(name, engineReason));
+			return;
+		}
+		if (extraReason) {
+			steps.push(skipped(name, extraReason));
+			return;
+		}
+		steps.push(planned(name));
+	};
+
+	add("Formatting (js/ts)", hasJsTs(projectInfo));
+	add(
+		"Formatting (python)",
+		projectInfo.languages.includes("python") && Boolean(projectInfo.installedTools.ruff),
+	);
+	add(
+		"Formatting (go)",
+		projectInfo.languages.includes("go") && Boolean(projectInfo.installedTools.gofmt),
+	);
+	add(
+		"Formatting (rust)",
+		projectInfo.languages.includes("rust") && Boolean(projectInfo.installedTools.rustfmt),
+	);
+	add(
+		"Formatting (ruby)",
+		projectInfo.languages.includes("ruby") && Boolean(projectInfo.installedTools.rubocop),
+		safe ? SKIPPED_BY_SAFE : undefined,
+	);
+	add(
+		"Formatting (php)",
+		projectInfo.languages.includes("php") && Boolean(projectInfo.installedTools["php-cs-fixer"]),
+		safe ? SKIPPED_BY_SAFE : undefined,
+	);
+	return steps;
+};
+
+const planForce = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	options: { safe: boolean; forceRequested: boolean },
+): FixPlanStep[] => {
+	if (!options.forceRequested) return [];
+	const reason = options.safe ? SKIPPED_BY_SAFE : "";
+	const steps: FixPlanStep[] = [];
+	if (hasJsTs(projectInfo)) {
+		steps.push(
+			reason
+				? skipped("Remove unused files", reason)
+				: gated("Remove unused files", config.engines["code-quality"], DISABLED_IN_CONFIG),
+		);
+	}
+	steps.push(
+		reason
+			? skipped("Dependency audit fixes", reason)
+			: gated("Dependency audit fixes", config.engines.security, DISABLED_IN_CONFIG),
+	);
+	if (projectInfo.frameworks.includes("expo")) {
+		const expoOn = config.lint.expoDoctor;
+		steps.push(
+			reason
+				? skipped("Expo dependency alignment", reason)
+				: gated("Expo dependency alignment", expoOn, "Expo Doctor is not enabled"),
+		);
+	}
+	return steps;
+};
+
+export const buildFixPlan = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	options: FixPlanOptions = {},
+): FixPlanStep[] => {
+	const safe = Boolean(options.safe);
+	const forceRequested = Boolean(options.force);
+	return [
+		...planAiSlop(config, safe),
+		...planQualityStep("Unused declarations", projectInfo, config, safe),
+		...planLint(projectInfo, config, safe),
+		...planQualityStep("Unused dependencies", projectInfo, config, safe),
+		...planFormatters(projectInfo, config, safe),
+		...planForce(projectInfo, config, { safe, forceRequested }),
+	];
+};
+
 export const buildFixStepNames = (
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: FixStepPlanOptions,
-): string[] => {
-	const stepNames: string[] = [];
+	options: FixPlanOptions = {},
+): string[] =>
+	buildFixPlan(projectInfo, config, options)
+		.filter((step) => step.status === "planned")
+		.map((step) => step.name);
 
-	if (config.engines["ai-slop"]) {
-		stepNames.push("Unused imports", "Dead code & comments");
-	}
-
-	if (config.engines.lint) {
-		if (hasJsTs(projectInfo)) {
-			stepNames.push("Lint fixes (js/ts)");
-		}
-		if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
-			stepNames.push("Lint fixes (python)");
-		}
-		if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
-			stepNames.push("Lint fixes (ruby)");
-		}
-	}
-
-	if (config.engines["code-quality"] && hasJsTs(projectInfo)) {
-		stepNames.push("Unused dependencies");
-	}
-
-	if (config.engines.format) {
-		if (hasJsTs(projectInfo)) {
-			stepNames.push("Formatting (js/ts)");
-		}
-		if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
-			stepNames.push("Formatting (python)");
-		}
-		if (projectInfo.languages.includes("go") && projectInfo.installedTools.gofmt) {
-			stepNames.push("Formatting (go)");
-		}
-		if (projectInfo.languages.includes("rust") && projectInfo.installedTools.rustfmt) {
-			stepNames.push("Formatting (rust)");
-		}
-		if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
-			stepNames.push("Formatting (ruby)");
-		}
-		if (projectInfo.languages.includes("php") && projectInfo.installedTools["php-cs-fixer"]) {
-			stepNames.push("Formatting (php)");
-		}
-	}
-
-	if (options.force) {
-		if (config.engines["code-quality"] && hasJsTs(projectInfo)) {
-			stepNames.push("Remove unused files");
-		}
-		if (config.engines.security) {
-			stepNames.push("Dependency audit fixes");
-		}
-		if (projectInfo.frameworks.includes("expo") && config.lint.expoDoctor) {
-			stepNames.push("Expo dependency alignment");
-		}
-	}
-
-	return stepNames;
-};
+export const skippedFixSteps = (plan: FixPlanStep[]): FixPlanStep[] =>
+	plan.filter((step) => step.status === "skipped");

--- a/src/commands/fix-render.ts
+++ b/src/commands/fix-render.ts
@@ -47,3 +47,5 @@ export const buildFixRender = (input: BuildFixRenderInput): string => {
 			: "";
 	return `${header}${rail}${tail}`;
 };
+
+export const NO_CHANGES_APPLIED = "No changes were applied.";

--- a/src/commands/fix-steps.ts
+++ b/src/commands/fix-steps.ts
@@ -17,7 +17,6 @@ const uniqueFileCount = (diagnostics: Diagnostic[]): number =>
 	new Set(diagnostics.map((d) => d.filePath)).size;
 
 export interface RunFixStepOptions {
-	/** Detect only. Never invoke the mutating fixer. */
 	dryRun?: boolean;
 }
 

--- a/src/commands/fix-steps.ts
+++ b/src/commands/fix-steps.ts
@@ -16,13 +16,31 @@ export interface FixStepResult {
 const uniqueFileCount = (diagnostics: Diagnostic[]): number =>
 	new Set(diagnostics.map((d) => d.filePath)).size;
 
+export interface RunFixStepOptions {
+	/** Detect only. Never invoke the mutating fixer. */
+	dryRun?: boolean;
+}
+
 export const runOneFixStep = async (
 	name: string,
 	detect: () => Promise<Diagnostic[]>,
 	applyFix: () => Promise<void>,
+	options: RunFixStepOptions = {},
 ): Promise<FixStepResult> => {
 	const started = performance.now();
 	const before = await detect();
+	if (options.dryRun) {
+		return {
+			name,
+			beforeIssues: before.length,
+			afterIssues: before.length,
+			resolvedIssues: 0,
+			beforeFiles: uniqueFileCount(before),
+			failed: false,
+			elapsedMs: performance.now() - started,
+			afterDiagnostics: before,
+		};
+	}
 	let applyError: unknown = null;
 	if (before.length > 0) {
 		try {
@@ -65,3 +83,15 @@ export const statusFor = (s: FixStepResult): RailStep["status"] => {
 	if (s.afterIssues > 0) return "warn";
 	return "done";
 };
+
+const findingLabel = (count: number): string => (count === 1 ? "finding" : "findings");
+const fileLabel = (count: number): string => (count === 1 ? "file" : "files");
+
+export const describePreviewStep = (result: FixStepResult): string => {
+	if (result.beforeIssues === 0) {
+		return `${result.name} - 0 findings`;
+	}
+	return `${result.name} - ${result.beforeIssues} ${findingLabel(result.beforeIssues)} in ${result.beforeFiles} ${fileLabel(result.beforeFiles)}`;
+};
+
+export const describeSkippedStep = (name: string, reason: string): string => `${name} - ${reason}`;

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -8,7 +8,7 @@ import { calculateScore } from "../scoring/index.js";
 import { withCommandLifecycle } from "../telemetry/index.js";
 import { renderHeader } from "../ui/header.js";
 import { LiveRail } from "../ui/live-rail.js";
-import { log } from "../ui/logger.js";
+import { log, renderHintLine } from "../ui/logger.js";
 import { theme as defaultTheme, style } from "../ui/theme.js";
 import { discoverProject } from "../utils/discover.js";
 import { APP_VERSION } from "../version.js";
@@ -23,7 +23,16 @@ import {
 	runFormattingStep,
 	runLintSteps,
 } from "./fix-pipeline.js";
-import { describeStep, type FixStepResult, runOneFixStep, statusFor } from "./fix-steps.js";
+import { buildFixPlan, skippedFixSteps } from "./fix-plan.js";
+import { NO_CHANGES_APPLIED } from "./fix-render.js";
+import {
+	describePreviewStep,
+	describeSkippedStep,
+	describeStep,
+	type FixStepResult,
+	runOneFixStep,
+	statusFor,
+} from "./fix-steps.js";
 import { buildScanRender } from "./scan.js";
 
 export { buildFixRender } from "./fix-render.js";
@@ -33,6 +42,8 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
+	/** Detect and print the plan without invoking mutating fixers */
+	dryRun?: boolean;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;
 	/** Print the prompt to stdout instead of launching an agent */
@@ -98,9 +109,52 @@ export const fixCommand = async (
 			config: config.telemetry,
 			languages: projectInfo.languages,
 			fileCount: projectInfo.sourceFileCount,
+			properties: options.dryRun ? { dry_run: true } : undefined,
 		},
 		() => runFixBody(resolvedDir, config, options, projectInfo),
 	);
+};
+
+const runFixPipeline = async (deps: PipelineDeps, safe: boolean): Promise<void> => {
+	await runAiSlopSteps(deps);
+	if (!safe) {
+		await runDeclarationStep(deps);
+		await runLintSteps(deps);
+		await runDependencyStep(deps);
+	}
+	await runFormattingStep(deps);
+	await runForceSteps(deps);
+};
+
+const finishDryRun = (input: {
+	rail: LiveRail;
+	steps: FixStepResult[];
+	projectInfo: Awaited<ReturnType<typeof discoverProject>>;
+	config: AislopConfig;
+	options: FixOptions;
+}): { exitCode: number; fixSteps: number; fixResolved: number } => {
+	const plan = buildFixPlan(input.projectInfo, input.config, {
+		force: Boolean(input.options.force),
+		safe: Boolean(input.options.safe),
+	});
+	const ran = new Set(input.steps.map((step) => step.name));
+	for (const step of skippedFixSteps(plan)) {
+		if (ran.has(step.name)) continue;
+		input.rail.complete({
+			status: "skipped",
+			label: describeSkippedStep(step.name, step.reason ?? "skipped"),
+		});
+	}
+	if (input.steps.length === 0 && skippedFixSteps(plan).length === 0) {
+		input.rail.complete({ status: "skipped", label: "No applicable auto-fixers found" });
+	}
+	input.rail.finish({ footer: "Preview · no changes applied" });
+	process.stdout.write(`\n${renderHintLine(NO_CHANGES_APPLIED)}`);
+	return {
+		exitCode: 0,
+		fixSteps: input.steps.length,
+		fixResolved: 0,
+	};
 };
 
 const runFixBody = async (
@@ -113,11 +167,12 @@ const runFixBody = async (
 	const showHeader = options.showHeader !== false;
 	const projectName = projectInfo.projectName ?? "project";
 
+	const dryRun = Boolean(options.dryRun);
 	if (showHeader) {
 		process.stdout.write(
 			renderHeader({
 				version: APP_VERSION,
-				command: "Fix run",
+				command: dryRun ? "Fix plan" : "Fix run",
 				context: [projectName],
 				brand: options.printBrand !== false,
 			}),
@@ -127,7 +182,7 @@ const runFixBody = async (
 	const safe = Boolean(options.safe);
 	const context = createEngineContext(resolvedDir, projectInfo, config, { safe });
 	const steps: FixStepResult[] = [];
-	const rail = new LiveRail();
+	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
 
 	const runStep = async (
 		name: string,
@@ -135,9 +190,12 @@ const runFixBody = async (
 		applyFix: () => Promise<void>,
 	) => {
 		rail.start(name);
-		const result = await runOneFixStep(name, detect, applyFix);
+		const result = await runOneFixStep(name, detect, applyFix, { dryRun });
 		steps.push(result);
-		rail.complete({ status: statusFor(result), label: describeStep(result) });
+		rail.complete({
+			status: dryRun ? "done" : statusFor(result),
+			label: dryRun ? describePreviewStep(result) : describeStep(result),
+		});
 		return result;
 	};
 
@@ -152,17 +210,17 @@ const runFixBody = async (
 		runStep,
 	};
 
-	await runAiSlopSteps(pipelineDeps);
-	// Safe mode skips the steps that delete code or rewrite behaviour/attributes.
-	if (!safe) {
-		await runDeclarationStep(pipelineDeps);
-		await runLintSteps(pipelineDeps);
-		await runDependencyStep(pipelineDeps);
+	await runFixPipeline(pipelineDeps, safe);
+
+	if (dryRun) {
+		return finishDryRun({
+			rail,
+			steps,
+			projectInfo,
+			config,
+			options,
+		});
 	}
-
-	await runFormattingStep(pipelineDeps);
-
-	await runForceSteps(pipelineDeps);
 
 	const totalResolved = steps.reduce((sum, s) => sum + s.resolvedIssues, 0);
 

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -42,7 +42,6 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
-	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;

--- a/src/engines/format/dotnet-format.ts
+++ b/src/engines/format/dotnet-format.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import micromatch from "micromatch";
 import { normalizeExcludePatterns } from "../../utils/exclude.js";
@@ -68,7 +69,16 @@ export const parseDotnetFormatReport = (json: string, rootDirectory: string): Di
 	return diagnostics;
 };
 
-const reportPathFor = (rootDirectory: string): string => path.join(rootDirectory, REPORT_FILENAME);
+// The report is scratch state, so it lives outside the tree. Writing it into the
+// project meant an unconditional delete of that path, destroying a same-named user file.
+const withReportPath = async <T>(run: (reportPath: string) => Promise<T>): Promise<T> => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-dotnet-format-"));
+	try {
+		return await run(path.join(dir, REPORT_FILENAME));
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+};
 
 // Syntax micromatch accepts that Microsoft.Extensions.FileSystemGlobbing does
 // not: character classes, extglobs, negation, and escapes have no equivalent,
@@ -118,37 +128,35 @@ const excludeOption = (scope: DotnetFormatExcludeScope): string[] =>
 // the check to the same excludes the fixer honors keeps a step's before/after
 // counts consistent; a pattern dotnet format cannot express is left to
 // filterExcludedDiagnostics, which reads nothing but the reported paths.
-const checkTarget = async (context: EngineContext, target: string): Promise<Diagnostic[]> => {
-	const reportPath = reportPathFor(context.rootDirectory);
-	const scope = buildDotnetFormatExcludeScope(context.excludePatterns);
-	try {
-		await runSubprocess(
-			"dotnet",
-			[
-				"format",
-				"whitespace",
-				target,
-				"--no-restore",
-				...excludeOption(scope),
-				"--verify-no-changes",
-				"--report",
-				reportPath,
-			],
-			{ cwd: context.rootDirectory, timeout: 180000 },
-		);
-		let json: string;
+const checkTarget = async (context: EngineContext, target: string): Promise<Diagnostic[]> =>
+	withReportPath(async (reportPath) => {
+		const scope = buildDotnetFormatExcludeScope(context.excludePatterns);
 		try {
-			json = fs.readFileSync(reportPath, "utf-8");
-			fs.rmSync(reportPath, { force: true });
+			await runSubprocess(
+				"dotnet",
+				[
+					"format",
+					"whitespace",
+					target,
+					"--no-restore",
+					...excludeOption(scope),
+					"--verify-no-changes",
+					"--report",
+					reportPath,
+				],
+				{ cwd: context.rootDirectory, timeout: 180000 },
+			);
+			let json: string;
+			try {
+				json = fs.readFileSync(reportPath, "utf-8");
+			} catch {
+				return [];
+			}
+			return parseDotnetFormatReport(json, context.rootDirectory);
 		} catch {
 			return [];
 		}
-		return parseDotnetFormatReport(json, context.rootDirectory);
-	} catch {
-		fs.rmSync(reportPath, { force: true });
-		return [];
-	}
-};
+	});
 
 export const runDotnetFormat = async (context: EngineContext): Promise<Diagnostic[]> => {
 	// Silent restore-evidence gate: the skip notice is the

--- a/src/ui/command-reference-data.ts
+++ b/src/ui/command-reference-data.ts
@@ -37,7 +37,14 @@ const FIX_AGENT_FLAGS = [
 	"--crush",
 ];
 
-const FIX_FLAGS = ["-d, --verbose", "-f, --force", "--safe", "-p, --prompt", ...FIX_AGENT_FLAGS];
+const FIX_FLAGS = [
+	"-d, --verbose",
+	"-f, --force",
+	"--safe",
+	"--dry-run",
+	"-p, --prompt",
+	...FIX_AGENT_FLAGS,
+];
 
 const AGENT_FLAGS = [
 	"--provider <provider>",

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -227,6 +227,7 @@ describe("cli ergonomics", () => {
 		expect(fix.status).toBe(0);
 		expect(fix.stdout).toContain("Auto-fix findings or hand off to a coding agent");
 		expect(fix.stdout).toContain("--safe");
+		expect(fix.stdout).toContain("--dry-run");
 		expect(fix.stdout).toContain("--claude");
 		expect(fix.stdout).toContain("--codex");
 		expect(fix.stdout).toContain("--opencode");

--- a/tests/dotnet-format.test.ts
+++ b/tests/dotnet-format.test.ts
@@ -105,6 +105,22 @@ describe("runDotnetFormat restore-evidence gating", () => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
+	it("leaves a user file named like the report alone", async () => {
+		// The report used to be written into the project root and deleted on every path,
+		// so a file a user happened to own at that name was destroyed by a scan.
+		const warmDir = path.join(tmpDir, "Warm");
+		fs.mkdirSync(path.join(warmDir, "obj"), { recursive: true });
+		fs.writeFileSync(path.join(warmDir, "Warm.csproj"), "");
+		fs.writeFileSync(path.join(warmDir, "obj", "project.assets.json"), "{}");
+		const userFile = path.join(tmpDir, ".aislop-dotnet-format.json");
+		fs.writeFileSync(userFile, '{"mine":true}');
+
+		await runDotnetFormat(formatContext(tmpDir));
+
+		expect(fs.existsSync(userFile)).toBe(true);
+		expect(fs.readFileSync(userFile, "utf-8")).toBe('{"mine":true}');
+	});
+
 	it("formats only projects with restore evidence, silently skipping cold ones", async () => {
 		const warmDir = path.join(tmpDir, "Warm");
 		fs.mkdirSync(path.join(warmDir, "obj"), { recursive: true });

--- a/tests/fix-force.test.ts
+++ b/tests/fix-force.test.ts
@@ -1,7 +1,9 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
 import {
 	collectPnpmOverrides,
 	guardOverrides,
@@ -12,6 +14,9 @@ import {
 	patchedRangeToVersion,
 	readInstalledVersions,
 } from "../src/commands/fix-force.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
 
 describe("patchedRangeToVersion", () => {
 	it("handles a simple >=", () => {
@@ -215,5 +220,106 @@ describe("readInstalledVersions", () => {
 
 	it("omits packages that are not installed anywhere", () => {
 		expect(readInstalledVersions(tmpDir, ["missing"]).has("missing")).toBe(false);
+	});
+});
+
+const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+describe("fix --dry-run --force", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("reports aggressive steps without mutating manifests, lockfiles, or dependencies", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-force-dry-run-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		const packageJson = `${JSON.stringify({ name: "force-preview", version: "1.0.0" }, null, 2)}\n`;
+		const lockfile = "lockfile-must-not-change\n";
+		fs.writeFileSync(path.join(root, "package.json"), packageJson);
+		fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), lockfile);
+		fs.mkdirSync(path.join(root, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(root, "src/app.ts"),
+			'import { leftover } from "./missing";\nexport const value = 1;\n',
+		);
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "init", "--no-verify"]);
+		const before = posixTree(root);
+		const statusBefore = execFileSync("git", ["status", "--porcelain", "-uall"], {
+			cwd: root,
+			encoding: "utf-8",
+		});
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: {
+				...DEFAULT_CONFIG.engines,
+				format: false,
+				lint: false,
+				architecture: false,
+				security: false,
+				"code-quality": true,
+				"ai-slop": true,
+			},
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, { verbose: false, dryRun: true, force: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Remove unused files");
+		expect(output).toContain("Dependency audit fixes");
+		expect(output).not.toContain("running pnpm");
+		expect(output).not.toContain("npm audit");
+		expect(output).not.toContain("expo install");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+		expect(fs.readFileSync(path.join(root, "package.json"), "utf-8")).toBe(packageJson);
+		expect(fs.readFileSync(path.join(root, "pnpm-lock.yaml"), "utf-8")).toBe(lockfile);
+		expect(
+			execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" }),
+		).toBe(statusBefore);
 	});
 });

--- a/tests/fix-plan.test.ts
+++ b/tests/fix-plan.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { buildFixStepNames } from "../src/commands/fix-plan.js";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
+import { buildFixPlan, buildFixStepNames } from "../src/commands/fix-plan.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
+import { runOneFixStep } from "../src/commands/fix-steps.js";
 import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { AislopConfig } from "../src/config/index.js";
+import type { Diagnostic } from "../src/engines/types.js";
 import type { ProjectInfo } from "../src/utils/discover.js";
 
 const makeProjectInfo = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
@@ -137,5 +145,229 @@ describe("buildFixStepNames", () => {
 		};
 		const steps = buildFixStepNames(makeProjectInfo(), config, {});
 		expect(steps).toHaveLength(0);
+	});
+
+	it("includes duplicate-import and unused-declaration steps for JS/TS projects", () => {
+		const steps = buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, {});
+		expect(steps).toContain("Duplicate imports");
+		expect(steps).toContain("Unused declarations");
+	});
+
+	it("marks safe-incompatible steps as skipped by --safe", () => {
+		const plan = buildFixPlan(makeProjectInfo(), DEFAULT_CONFIG, { safe: true });
+		expect(plan.find((step) => step.name === "Narrative comments")?.status).toBe("planned");
+		expect(plan.find((step) => step.name === "Dead code & comments")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Unused declarations")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Lint fixes (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Unused dependencies")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, { safe: true })).not.toContain(
+			"Dead code & comments",
+		);
+	});
+
+	it("reports aggressive steps as skipped by --safe when both flags are set", () => {
+		const plan = buildFixPlan(makeProjectInfo(), DEFAULT_CONFIG, { safe: true, force: true });
+		expect(plan.find((step) => step.name === "Remove unused files")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Dependency audit fixes")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(
+			buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, { safe: true, force: true }),
+		).not.toContain("Remove unused files");
+	});
+
+	it("marks engine-gated steps as disabled in config", () => {
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: { ...DEFAULT_CONFIG.engines, lint: false, format: false },
+		};
+		const plan = buildFixPlan(makeProjectInfo(), config, {});
+		expect(plan.find((step) => step.name === "Lint fixes (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "disabled in config",
+		});
+		expect(plan.find((step) => step.name === "Formatting (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "disabled in config",
+		});
+	});
+});
+
+const git = (cwd: string, args: string[]) => {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+const write = (root: string, rel: string, body: string) => {
+	const abs = path.join(root, rel);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, body, "utf-8");
+};
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const gitStatus = (root: string): string =>
+	execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" });
+
+const snapshot = (root: string) => ({ tree: posixTree(root), status: gitStatus(root) });
+
+const previewConfig = (): AislopConfig => ({
+	...DEFAULT_CONFIG,
+	engines: {
+		...DEFAULT_CONFIG.engines,
+		format: false,
+		lint: false,
+		"code-quality": false,
+		architecture: false,
+		security: false,
+		"ai-slop": true,
+	},
+	telemetry: { enabled: false },
+});
+
+const UNUSED = 'import { leftover } from "./missing";\nexport const value = 1;\n';
+const UNTRACKED = "untracked leftover that must not be touched\n";
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+const initPreviewRepo = (): string => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-dry-run-"));
+	git(root, ["init"]);
+	git(root, ["config", "user.email", "test@example.com"]);
+	git(root, ["config", "user.name", "test"]);
+	git(root, ["config", "commit.gpgsign", "false"]);
+	write(root, "src/app.ts", UNUSED);
+	git(root, ["add", "src/app.ts"]);
+	git(root, ["commit", "-m", "init", "--no-verify"]);
+	write(root, "notes.txt", UNTRACKED);
+	return root;
+};
+
+describe("runOneFixStep dry-run", () => {
+	it("never invokes the mutating fixer", async () => {
+		let applied = 0;
+		const finding: Diagnostic = {
+			filePath: "src/app.ts",
+			engine: "ai-slop",
+			rule: "ai-slop/unused-import",
+			severity: "warning",
+			message: "unused",
+			help: "",
+			line: 1,
+			column: 1,
+			category: "Imports",
+			fixable: true,
+		};
+		const result = await runOneFixStep(
+			"Unused imports",
+			async () => [finding],
+			async () => {
+				applied += 1;
+			},
+			{ dryRun: true },
+		);
+		expect(applied).toBe(0);
+		expect(result.resolvedIssues).toBe(0);
+		expect(result.beforeIssues).toBe(1);
+		expect(result.beforeFiles).toBe(1);
+	});
+});
+
+describe("fix --dry-run", () => {
+	const repos: string[] = [];
+
+	afterEach(() => {
+		for (const root of repos.splice(0)) {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("prints the plan and does not modify tracked, untracked, or git status", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		const before = snapshot(root);
+
+		const output = await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Unused imports");
+		expect(output).toMatch(/1 finding/);
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(snapshot(root)).toEqual(before);
+	});
+
+	it("is deterministic on an unchanged repository", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		const run = () =>
+			captureStdout(() =>
+				fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: true }),
+			);
+		const first = await run();
+		const second = await run();
+		expect(second).toBe(first);
+	});
+
+	it("leaves the unused import in place so a later applying run can still fix it", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: false }),
+		);
+		expect(fs.readFileSync(path.join(root, "src/app.ts"), "utf-8")).toBe(UNUSED);
+		await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: false, showHeader: false }),
+		);
+		expect(fs.readFileSync(path.join(root, "src/app.ts"), "utf-8")).not.toBe(UNUSED);
+		expect(fs.readFileSync(path.join(root, "notes.txt"), "utf-8")).toBe(UNTRACKED);
 	});
 });

--- a/tests/fix-safe-mode.test.ts
+++ b/tests/fix-safe-mode.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
 import type { PipelineDeps } from "../src/commands/fix-pipeline.js";
 import { runAiSlopSteps, runFormattingStep } from "../src/commands/fix-pipeline.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
 import type { FixStepResult } from "../src/commands/fix-steps.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { AislopConfig } from "../src/config/index.js";
 
 const recordingDeps = (
@@ -86,5 +93,92 @@ describe("runFormattingStep safe mode", () => {
 		await runFormattingStep(deps);
 
 		expect(steps).toEqual(["Formatting (ruby)", "Formatting (php)"]);
+	});
+});
+
+const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
+
+const write = (root: string, rel: string, body: string) => {
+	const abs = path.join(root, rel);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, body, "utf-8");
+};
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+describe("fix --dry-run --safe", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("lists steps skipped by --safe and does not write files", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-safe-dry-run-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		write(root, "src/app.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "init", "--no-verify"]);
+		const before = posixTree(root);
+		const statusBefore = execFileSync("git", ["status", "--porcelain", "-uall"], {
+			cwd: root,
+			encoding: "utf-8",
+		});
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, { verbose: false, dryRun: true, safe: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("skipped by --safe");
+		expect(output).toContain("Dead code & comments");
+		expect(output).toContain("Unused declarations");
+		expect(output).toContain("Lint fixes (js/ts)");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+		expect(
+			execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" }),
+		).toBe(statusBefore);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds `aislop fix --dry-run`. Detection and planning still run; mutating fixers, package-manager commands, and framework installs do not. The command prints planned steps (eligible findings and affected file counts), steps skipped by configuration or `--safe`, and a clear `No changes were applied.` line. `--dry-run --force` lists aggressive steps the same way and still writes nothing.

## Type of change

- [x] New feature (adds functionality)

## Acceptance criteria

- [x] `--dry-run` does not modify tracked files, untracked files, configuration, lockfiles, or dependencies.
- [x] The output lists planned fix steps, findings eligible for each step, affected file counts, and steps skipped by configuration or `--safe`.
- [x] `--dry-run --force` reports aggressive steps without running package-manager or framework mutation commands.
- [x] The command clearly states that no changes were applied.
- [x] The result is deterministic for an unchanged repository.
- [x] Dry-run telemetry uses the existing allowlisted `dry_run` aggregate property only.
- [x] Tests compare file contents and repository status before and after the command.

Out of scope (v1): exact patches. Detection reports eligible detectors and files; `runOneFixStep(..., { dryRun: true })` never calls the mutating fixer.

## Validation

```bash
pnpm vitest run tests/fix-plan.test.ts tests/fix-safe-mode.test.ts tests/fix-force.test.ts
pnpm typecheck
pnpm scan --exclude tools/oss-benchmark.mjs
```

- focused suites: pass (includes git-status and file-content snapshots)
- `pnpm typecheck`: pass
- `pnpm test`: 200 files, 2074 tests pass
- self-scan of this change: 100/100, 0 findings

`tools/oss-benchmark.mjs` is an untracked local file on this checkout, not part of the PR. It is excluded from the self-scan so the score reflects the committed tree.

Fixes #320