### PR TITLE
feat(fix): honour --changes, --staged, and --base

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ The deterministic layer beneath [`aislop agent`](#run-a-local-repair-agent): aut
 ```bash
 aislop fix                 # auto-fixes
 aislop fix --dry-run       # preview planned steps without writing files
+aislop fix --changes       # only rewrite files changed vs HEAD
+aislop fix --staged        # only rewrite staged files
 aislop fix -d              # detailed fix progress
 aislop fix --safe          # only reversible fixes (imports, comment removal, safe formatters)
 aislop fix -f              # aggressive: deps, unused files

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,6 +91,9 @@ Use `--changes --base origin/<target>` to gate a pull request on only the files 
 | `-f, --force` | Run aggressive fixes: dependency audit, framework alignment, unused file removal |
 | `--safe` | Only apply reversible fixes |
 | `--dry-run` | Print planned fix steps, eligible findings, and skipped steps without writing files |
+| `--changes` | Only fix changed files (defaults to diffing `HEAD`) |
+| `--base <ref>` | Diff base for `--changes`, e.g. `origin/main` (default `HEAD`) |
+| `--staged` | Only fix staged files |
 | `-p, --prompt` | Print an agent-ready prompt for remaining issues |
 
 Agent handoff flags: `--claude`, `--codex`, `--cursor`, `--windsurf`, `--vscode`, `--amp`, `--antigravity`, `--deep-agents`, `--gemini`, `--kimi`, `--opencode`, `--warp`, `--aider`, `--goose`, `--pi`, `--crush`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { registerAgentCommand } from "./cli/agent-command.js";
 import { registerHookAliases, registerHookCommand } from "./cli/hook-command.js";
 import { registerExtraCommands } from "./cli-extra-commands.js";
@@ -129,6 +129,9 @@ const fixProgram = program
 		"only apply reversible fixes (imports, comment removal, safe formatters); skip anything that deletes code, rewrites behaviour, or runs unsafe formatter configs",
 	)
 	.option("--dry-run", "print planned fix steps without writing files")
+	.addOption(new Option("--changes", "only fix changed files (git diff)").conflicts("staged"))
+	.addOption(new Option("--staged", "only fix staged files").conflicts("changes"))
+	.option("--base <ref>", "diff base for --changes, e.g. origin/main (default HEAD)")
 	.option("-p, --prompt", "print a prompt for your coding agent to fix remaining issues");
 
 for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
@@ -140,6 +143,9 @@ fixProgram.action(async (directory = ".", _flags, command) => {
 		force: Boolean(flags.force),
 		safe: Boolean(flags.safe),
 		dryRun: Boolean(flags.dryRun),
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: typeof flags.base === "string" ? flags.base : undefined,
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});

--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -1,5 +1,6 @@
 import type { AislopConfig } from "../config/index.js";
 import type { EngineContext } from "../engines/types.js";
+import type { Language } from "../utils/discover.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import type { ProjectInfo } from "./fix-pipeline.js";
 import type { ScanFileScope } from "./scan-file-scope.js";
@@ -8,7 +9,11 @@ export const createEngineContext = (
 	rootDirectory: string,
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: { safe?: boolean; scope?: ScanFileScope } = {},
+	options: {
+		safe?: boolean;
+		scope?: ScanFileScope;
+		dependencyAuditLanguages?: Language[];
+	} = {},
 ): EngineContext => ({
 	rootDirectory,
 	languages: projectInfo.languages,
@@ -27,6 +32,9 @@ export const createEngineContext = (
 				projectFiles: options.scope.projectFiles,
 				dependencyAuditFiles: options.scope.dependencyAuditFiles,
 				dependencyAuditScope: options.scope.dependencyAuditScope,
+				// Scoped languages come from the selected files, so a manifest-only scope has
+				// none. Dependency work is about the project, not the selection.
+				dependencyAuditLanguages: options.dependencyAuditLanguages,
 			}
 		: {}),
 });

--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -2,12 +2,13 @@ import type { AislopConfig } from "../config/index.js";
 import type { EngineContext } from "../engines/types.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import type { ProjectInfo } from "./fix-pipeline.js";
+import type { ScanFileScope } from "./scan-file-scope.js";
 
 export const createEngineContext = (
 	rootDirectory: string,
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: { safe?: boolean } = {},
+	options: { safe?: boolean; scope?: ScanFileScope } = {},
 ): EngineContext => ({
 	rootDirectory,
 	languages: projectInfo.languages,
@@ -19,4 +20,13 @@ export const createEngineContext = (
 		? { ...projectInfo.installedTools, rubocop: false, "php-cs-fixer": false }
 		: projectInfo.installedTools,
 	config: { quality: config.quality, security: config.security, lint: config.lint },
+	...(options.scope
+		? {
+				files: [...new Set([...options.scope.files, ...options.scope.testFiles])],
+				testFiles: options.scope.testFiles,
+				projectFiles: options.scope.projectFiles,
+				dependencyAuditFiles: options.scope.dependencyAuditFiles,
+				dependencyAuditScope: options.scope.dependencyAuditScope,
+			}
+		: {}),
 });

--- a/src/commands/fix-formatting-pipeline.ts
+++ b/src/commands/fix-formatting-pipeline.ts
@@ -11,6 +11,7 @@ import { fixRuffFormat, runRuffFormat } from "../engines/format/ruff-format.js";
 import { log } from "../ui/logger.js";
 import type { PipelineDeps } from "./fix-pipeline.js";
 import { hasJsOrTs } from "./fix-pipeline-language.js";
+import { CANNOT_SCOPE_REASON, isScopedFix } from "./fix-scope.js";
 
 const skipUnsafeSafeFormatter = (deps: PipelineDeps, language: "ruby" | "php"): boolean => {
 	if (!deps.safe) return false;
@@ -51,7 +52,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Formatting (python)",
 			() => runRuffFormat(deps.context),
-			() => fixRuffFormat(deps.resolvedDir),
+			() => fixRuffFormat(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("python")) {
 		log.warn("Python detected but ruff is not installed; skipping Python formatting fixes.");
@@ -61,18 +62,22 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Formatting (go)",
 			() => runGofmt(deps.context),
-			() => fixGofmt(deps.resolvedDir),
+			() => fixGofmt(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("go")) {
 		log.warn("Go detected but gofmt is not installed; skipping Go formatting fixes.");
 	}
 
 	if (deps.projectInfo.languages.includes("rust") && deps.projectInfo.installedTools.rustfmt) {
-		await deps.runStep(
-			"Formatting (rust)",
-			() => runGenericFormatter(deps.context, "rust"),
-			() => fixGenericFormatter(deps.resolvedDir, "rust"),
-		);
+		if (isScopedFix(deps.context)) {
+			deps.skipStep?.("Formatting (rust)", CANNOT_SCOPE_REASON);
+		} else {
+			await deps.runStep(
+				"Formatting (rust)",
+				() => runGenericFormatter(deps.context, "rust"),
+				() => fixGenericFormatter(deps.context, "rust"),
+			);
+		}
 	} else if (deps.projectInfo.languages.includes("rust")) {
 		log.warn("Rust detected but rustfmt is not installed; skipping Rust formatting fixes.");
 	}
@@ -82,7 +87,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 			await deps.runStep(
 				"Formatting (ruby)",
 				() => runGenericFormatter(deps.context, "ruby"),
-				() => fixGenericFormatter(deps.resolvedDir, "ruby"),
+				() => fixGenericFormatter(deps.context, "ruby"),
 			);
 		}
 	} else if (deps.projectInfo.languages.includes("ruby")) {
@@ -97,7 +102,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 			await deps.runStep(
 				"Formatting (php)",
 				() => runGenericFormatter(deps.context, "php"),
-				() => fixGenericFormatter(deps.resolvedDir, "php"),
+				() => fixGenericFormatter(deps.context, "php"),
 			);
 		}
 	} else if (deps.projectInfo.languages.includes("php")) {
@@ -113,6 +118,8 @@ const runNativeFormattingSteps = async (deps: PipelineDeps): Promise<void> => {
 			log.warn(
 				"Skipping C# formatting: set lint.csharp.projectEvaluation: true only for repositories you trust.",
 			);
+		} else if (isScopedFix(deps.context)) {
+			deps.skipStep?.("Formatting (csharp)", CANNOT_SCOPE_REASON);
 		} else if (!skipUnscopableCsharpFormatter(deps)) {
 			await deps.runStep(
 				"Formatting (csharp)",

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -33,7 +33,7 @@ import { hasJsOrTs } from "./fix-pipeline-language.js";
 import {
 	isPathInFixScope,
 	MISSING_MANIFEST_REASON,
-	scopeIncludesDependencyManifest,
+	scopeIncludesManifestWrites,
 } from "./fix-scope.js";
 import type { FixStepResult } from "./fix-steps.js";
 
@@ -151,10 +151,17 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 	}
 };
 
+// Dependency work follows the project's languages, not the selection's: a scope holding
+// only package.json detects no source language but still needs the JS/TS fixers.
+const dependencyLanguages = (deps: PipelineDeps): ProjectInfo => ({
+	...deps.projectInfo,
+	languages: deps.context.dependencyAuditLanguages ?? deps.projectInfo.languages,
+});
+
 export const runDependencyStep = async (deps: PipelineDeps): Promise<void> => {
 	if (!deps.config.engines["code-quality"]) return;
-	if (!hasJsOrTs(deps.projectInfo)) return;
-	if (!scopeIncludesDependencyManifest(deps.context)) {
+	if (!hasJsOrTs(dependencyLanguages(deps))) return;
+	if (!scopeIncludesManifestWrites(deps.context)) {
 		deps.skipStep?.("Unused dependencies", MISSING_MANIFEST_REASON);
 		return;
 	}
@@ -186,7 +193,7 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	const railUpdate = (label: string) => deps.rail.setActiveLabel(label);
 
 	if (deps.config.engines.security) {
-		if (!scopeIncludesDependencyManifest(deps.context)) {
+		if (!scopeIncludesManifestWrites(deps.context)) {
 			deps.skipStep?.("Dependency audit fixes", MISSING_MANIFEST_REASON);
 		} else {
 			await deps.runStep(
@@ -198,7 +205,7 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	}
 
 	if (deps.projectInfo.frameworks.includes("expo") && deps.config.lint.expoDoctor) {
-		if (!scopeIncludesDependencyManifest(deps.context)) {
+		if (!scopeIncludesManifestWrites(deps.context)) {
 			deps.skipStep?.("Expo dependency alignment", MISSING_MANIFEST_REASON);
 		} else {
 			await deps.runStep(

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -30,6 +30,11 @@ import type { discoverProject } from "../utils/discover.js";
 import { fixExpoDependencies } from "./fix-expo.js";
 import { fixDependencyAudit } from "./fix-force.js";
 import { hasJsOrTs } from "./fix-pipeline-language.js";
+import {
+	isPathInFixScope,
+	MISSING_MANIFEST_REASON,
+	scopeIncludesDependencyManifest,
+} from "./fix-scope.js";
 import type { FixStepResult } from "./fix-steps.js";
 
 export { runFormattingStep } from "./fix-formatting-pipeline.js";
@@ -55,6 +60,7 @@ export interface PipelineDeps {
 	// Restrict to reversible fixes only (imports, comment removal, safe formatter runs).
 	safe: boolean;
 	runStep: RunStepFn;
+	skipStep?: (name: string, reason: string) => void;
 }
 
 export const runAiSlopSteps = async (deps: PipelineDeps): Promise<void> => {
@@ -128,7 +134,7 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Lint fixes (python)",
 			() => runRuffLint(deps.context),
-			() => (deps.force ? fixRuffLintForce(deps.resolvedDir) : fixRuffLint(deps.resolvedDir)),
+			() => (deps.force ? fixRuffLintForce(deps.context) : fixRuffLint(deps.context)),
 		);
 	} else if (deps.projectInfo.languages.includes("python")) {
 		log.warn("Python detected but ruff is not installed; skipping Python lint fixes.");
@@ -138,7 +144,7 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Lint fixes (ruby)",
 			() => runGenericLinter(deps.context, "ruby"),
-			() => fixRubyLint(deps.resolvedDir),
+			() => fixRubyLint(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("ruby")) {
 		log.warn("Ruby detected but rubocop is not installed; skipping Ruby lint fixes.");
@@ -148,6 +154,10 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 export const runDependencyStep = async (deps: PipelineDeps): Promise<void> => {
 	if (!deps.config.engines["code-quality"]) return;
 	if (!hasJsOrTs(deps.projectInfo)) return;
+	if (!scopeIncludesDependencyManifest(deps.context)) {
+		deps.skipStep?.("Unused dependencies", MISSING_MANIFEST_REASON);
+		return;
+	}
 
 	await deps.runStep(
 		"Unused dependencies",
@@ -162,26 +172,40 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	if (deps.config.engines["code-quality"] && hasJsOrTs(deps.projectInfo)) {
 		await deps.runStep(
 			"Remove unused files",
-			() => runKnipUnusedFiles(deps.resolvedDir),
-			() => fixUnusedFiles(deps.resolvedDir),
+			async () => {
+				const diagnostics = await runKnipUnusedFiles(deps.resolvedDir);
+				return diagnostics.filter((diagnostic) =>
+					isPathInFixScope(deps.context, diagnostic.filePath),
+				);
+			},
+			() =>
+				fixUnusedFiles(deps.resolvedDir, (filePath) => isPathInFixScope(deps.context, filePath)),
 		);
 	}
 
 	const railUpdate = (label: string) => deps.rail.setActiveLabel(label);
 
 	if (deps.config.engines.security) {
-		await deps.runStep(
-			"Dependency audit fixes",
-			() => runDependencyAudit(deps.context),
-			() => fixDependencyAudit(deps.context, railUpdate),
-		);
+		if (!scopeIncludesDependencyManifest(deps.context)) {
+			deps.skipStep?.("Dependency audit fixes", MISSING_MANIFEST_REASON);
+		} else {
+			await deps.runStep(
+				"Dependency audit fixes",
+				() => runDependencyAudit(deps.context),
+				() => fixDependencyAudit(deps.context, railUpdate),
+			);
+		}
 	}
 
 	if (deps.projectInfo.frameworks.includes("expo") && deps.config.lint.expoDoctor) {
-		await deps.runStep(
-			"Expo dependency alignment",
-			() => runExpoDoctor(deps.context),
-			() => fixExpoDependencies(deps.context, railUpdate),
-		);
+		if (!scopeIncludesDependencyManifest(deps.context)) {
+			deps.skipStep?.("Expo dependency alignment", MISSING_MANIFEST_REASON);
+		} else {
+			await deps.runStep(
+				"Expo dependency alignment",
+				() => runExpoDoctor(deps.context),
+				() => fixExpoDependencies(deps.context, railUpdate),
+			);
+		}
 	}
 };

--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -1,6 +1,7 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { EngineContext } from "../engines/types.js";
 import { projectRelativePosix } from "../utils/paths.js";
-import { isDependencyAuditInputFile } from "../utils/source-file-selection.js";
 import { collectScanFileScope, type ScanFileScope } from "./scan-file-scope.js";
 import { resolveScanScopeMode, type ScanOptions } from "./scan-options.js";
 import { scanTargetError } from "./scan-validation.js";
@@ -53,11 +54,26 @@ export const collectFixFileScope = (
 
 export const isScopedFix = (context: EngineContext): boolean => context.files !== undefined;
 
-export const scopeIncludesDependencyManifest = (context: EngineContext): boolean => {
+// Every dependency fixer rewrites package.json, and npm/pnpm/expo also rewrite the
+// lockfile. A scope holding only one of them would let a fix touch the other.
+const WRITTEN_LOCKFILES = [
+	"package-lock.json",
+	"pnpm-lock.yaml",
+	"yarn.lock",
+	"bun.lock",
+	"bun.lockb",
+];
+
+export const scopeIncludesManifestWrites = (context: EngineContext): boolean => {
 	if (!isScopedFix(context)) return true;
-	const files = context.dependencyAuditFiles ?? context.files ?? [];
-	return files.some((filePath) =>
-		isDependencyAuditInputFile(projectRelativePosix(context.rootDirectory, filePath)),
+	const selected = new Set(
+		(context.files ?? []).map((candidate) =>
+			projectRelativePosix(context.rootDirectory, candidate),
+		),
+	);
+	if (!selected.has("package.json")) return false;
+	return WRITTEN_LOCKFILES.every(
+		(name) => !fs.existsSync(path.join(context.rootDirectory, name)) || selected.has(name),
 	);
 };
 

--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -1,0 +1,73 @@
+import type { EngineContext } from "../engines/types.js";
+import { projectRelativePosix } from "../utils/paths.js";
+import { isDependencyAuditInputFile } from "../utils/source-file-selection.js";
+import { collectScanFileScope, type ScanFileScope } from "./scan-file-scope.js";
+import { resolveScanScopeMode, type ScanOptions } from "./scan-options.js";
+import { scanTargetError } from "./scan-validation.js";
+
+export interface FixScopeFlags {
+	changes?: boolean;
+	staged?: boolean;
+	base?: string;
+}
+
+export const CANNOT_SCOPE_REASON = "cannot honour an explicit file list under --changes/--staged";
+
+export const MISSING_MANIFEST_REASON = "no manifest or lockfile in the selected scope";
+
+export const fixScopeError = (resolvedDir: string, flags: FixScopeFlags): string | null => {
+	if (flags.changes && flags.staged) {
+		return "--changes and --staged cannot be used together.";
+	}
+	const options: ScanOptions = {
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: flags.base,
+		verbose: false,
+		json: false,
+	};
+	return scanTargetError(resolvedDir, options);
+};
+
+export const collectFixFileScope = (
+	rootDirectory: string,
+	excludePatterns: string[],
+	includePatterns: string[],
+	flags: FixScopeFlags,
+): ScanFileScope | null => {
+	const mode = resolveScanScopeMode({
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: flags.base,
+		verbose: false,
+		json: false,
+	});
+	if (mode.kind === "full") return null;
+	return collectScanFileScope({
+		excludePatterns,
+		includePatterns,
+		mode,
+		rootDirectory,
+	});
+};
+
+export const isScopedFix = (context: EngineContext): boolean => context.files !== undefined;
+
+export const scopeIncludesDependencyManifest = (context: EngineContext): boolean => {
+	if (!isScopedFix(context)) return true;
+	const files = context.dependencyAuditFiles ?? context.files ?? [];
+	return files.some((filePath) =>
+		isDependencyAuditInputFile(projectRelativePosix(context.rootDirectory, filePath)),
+	);
+};
+
+export const isPathInFixScope = (context: EngineContext, filePath: string): boolean => {
+	if (!isScopedFix(context)) return true;
+	const relative = projectRelativePosix(context.rootDirectory, filePath);
+	const allowed = new Set(
+		(context.files ?? []).map((candidate) =>
+			projectRelativePosix(context.rootDirectory, candidate),
+		),
+	);
+	return allowed.has(relative);
+};

--- a/src/commands/fix-steps.ts
+++ b/src/commands/fix-steps.ts
@@ -17,7 +17,6 @@ const uniqueFileCount = (diagnostics: Diagnostic[]): number =>
 	new Set(diagnostics.map((d) => d.filePath)).size;
 
 export interface RunFixStepOptions {
-	/** Detect only. Never invoke the mutating fixer. */
 	dryRun?: boolean;
 }
 

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -6,11 +6,13 @@ import { runEngines } from "../engines/orchestrator.js";
 import type { Diagnostic, EngineConfig, EngineResult } from "../engines/types.js";
 import { calculateScore } from "../scoring/index.js";
 import { withCommandLifecycle } from "../telemetry/index.js";
+import { renderDisplayRows } from "../ui/display.js";
 import { renderHeader } from "../ui/header.js";
 import { LiveRail } from "../ui/live-rail.js";
 import { log, renderHintLine } from "../ui/logger.js";
 import { theme as defaultTheme, style } from "../ui/theme.js";
-import { discoverProject } from "../utils/discover.js";
+import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
+import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { APP_VERSION } from "../version.js";
 import { launchAgent, printPrompt } from "./fix-code.js";
 import { createEngineContext } from "./fix-context.js";
@@ -25,6 +27,7 @@ import {
 } from "./fix-pipeline.js";
 import { buildFixPlan, skippedFixSteps } from "./fix-plan.js";
 import { NO_CHANGES_APPLIED } from "./fix-render.js";
+import { collectFixFileScope, fixScopeError } from "./fix-scope.js";
 import {
 	describePreviewStep,
 	describeSkippedStep,
@@ -44,6 +47,9 @@ interface FixOptions {
 	safe?: boolean;
 	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
+	changes?: boolean;
+	staged?: boolean;
+	base?: string;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;
 	/** Print the prompt to stdout instead of launching an agent */
@@ -97,6 +103,14 @@ export const fixCommand = async (
 			: `Not a directory: ${resolvedDir}`;
 		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
 			log.error(msg);
+			return { exitCode: 1 };
+		});
+	}
+
+	const scopeError = fixScopeError(resolvedDir, options);
+	if (scopeError) {
+		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
+			log.error(scopeError);
 			return { exitCode: 1 };
 		});
 	}
@@ -180,7 +194,31 @@ const runFixBody = async (
 	}
 
 	const safe = Boolean(options.safe);
-	const context = createEngineContext(resolvedDir, projectInfo, config, { safe });
+	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
+	const scope = collectFixFileScope(resolvedDir, excludePatterns, config.include, options);
+	const scopedProjectInfo = scope
+		? {
+				...projectInfo,
+				languages: detectSourceLanguages([...scope.files, ...scope.testFiles]),
+			}
+		: projectInfo;
+	const context = createEngineContext(resolvedDir, scopedProjectInfo, config, {
+		safe,
+		scope: scope ?? undefined,
+	});
+	if (scope) {
+		process.stdout.write(
+			`${renderDisplayRows(
+				[
+					{
+						label: "Scope",
+						value: `${scope.files.length + scope.testFiles.length} ${scope.scopeLabel}`,
+					},
+				],
+				{ indent: 1 },
+			).join("\n")}\n`,
+		);
+	}
 	const steps: FixStepResult[] = [];
 	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
 
@@ -199,15 +237,20 @@ const runFixBody = async (
 		return result;
 	};
 
+	const skipStep = (name: string, reason: string) => {
+		rail.complete({ status: "skipped", label: describeSkippedStep(name, reason) });
+	};
+
 	const pipelineDeps: PipelineDeps = {
 		rail,
 		context,
 		config,
 		resolvedDir,
-		projectInfo,
+		projectInfo: scopedProjectInfo,
 		force: safe ? false : Boolean(options.force),
 		safe,
 		runStep,
+		skipStep,
 	};
 
 	await runFixPipeline(pipelineDeps, safe);
@@ -216,7 +259,7 @@ const runFixBody = async (
 		return finishDryRun({
 			rail,
 			steps,
-			projectInfo,
+			projectInfo: scopedProjectInfo,
 			config,
 			options,
 		});
@@ -237,11 +280,20 @@ const runFixBody = async (
 	const verificationResults = await runEngines(
 		{
 			rootDirectory: resolvedDir,
-			languages: projectInfo.languages,
+			languages: scopedProjectInfo.languages,
 			frameworks: projectInfo.frameworks,
 			excludePatterns: context.excludePatterns,
 			installedTools: context.installedTools,
 			config: engineConfig,
+			...(scope
+				? {
+						files: context.files,
+						testFiles: context.testFiles,
+						projectFiles: context.projectFiles,
+						dependencyAuditFiles: context.dependencyAuditFiles,
+						dependencyAuditScope: context.dependencyAuditScope,
+					}
+				: {}),
 		},
 		buildPostFixVerificationEngines(config.engines),
 		() => {},
@@ -258,7 +310,7 @@ const runFixBody = async (
 		allDiagnostics,
 		config.scoring.weights,
 		config.scoring.thresholds,
-		projectInfo.sourceFileCount,
+		scope ? scope.files.length + scope.testFiles.length : projectInfo.sourceFileCount,
 		config.scoring.smoothing,
 		config.scoring.maxPerRule,
 	);
@@ -284,12 +336,14 @@ const runFixBody = async (
 				`\n ${style(t, "success", `Resolved ${totalResolved} issue${totalResolved === 1 ? "" : "s"}`)} ${arrow} ${style(t, "success", `${scoreResult.score} / 100 ${scoreResult.label}`)}\n`,
 			);
 		}
-		const language = projectInfo.languages[0] ?? "unknown";
+		const language = scopedProjectInfo.languages[0] ?? "unknown";
 		process.stdout.write(
 			buildScanRender({
 				projectName,
 				language,
-				fileCount: projectInfo.sourceFileCount,
+				fileCount: scope
+					? scope.files.length + scope.testFiles.length
+					: projectInfo.sourceFileCount,
 				results: scanResults,
 				diagnostics: actionableDiagnostics,
 				score: scoreResult,

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -45,7 +45,6 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
-	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
 	changes?: boolean;
 	staged?: boolean;

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -204,6 +204,7 @@ const runFixBody = async (
 	const context = createEngineContext(resolvedDir, scopedProjectInfo, config, {
 		safe,
 		scope: scope ?? undefined,
+		dependencyAuditLanguages: projectInfo.languages,
 	});
 	if (scope) {
 		process.stdout.write(

--- a/src/commands/scan-file-scope.ts
+++ b/src/commands/scan-file-scope.ts
@@ -20,7 +20,7 @@ interface ScanFileScopeRequest {
 	readonly rootDirectory: string;
 }
 
-interface ScanFileScope {
+export interface ScanFileScope {
 	readonly dependencyAuditFiles: string[];
 	readonly dependencyAuditScope: "files" | "full";
 	readonly files: string[];

--- a/src/engines/code-quality/knip.ts
+++ b/src/engines/code-quality/knip.ts
@@ -289,9 +289,13 @@ export const runKnipUnusedFiles = async (rootDirectory: string): Promise<Diagnos
 	return all.filter((d) => d.rule === "knip/files");
 };
 
-export const fixUnusedFiles = async (rootDirectory: string): Promise<void> => {
+export const fixUnusedFiles = async (
+	rootDirectory: string,
+	allow: (filePath: string) => boolean = () => true,
+): Promise<void> => {
 	const diagnostics = await runKnipUnusedFiles(rootDirectory);
 	for (const d of diagnostics) {
+		if (!allow(d.filePath)) continue;
 		const absolutePath = getSafeUnusedFilePath(rootDirectory, d.filePath);
 		if (absolutePath) {
 			fs.unlinkSync(absolutePath);

--- a/src/engines/format/generic.ts
+++ b/src/engines/format/generic.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Language } from "../../utils/discover.js";
 import { projectRelativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
@@ -113,24 +114,55 @@ export const runGenericFormatter = async (
 
 		const output = result.stdout || result.stderr;
 		if (!output) return [];
-		return config.parseOutput(output, context.rootDirectory).map((diagnostic) => ({
+		const diagnostics = config.parseOutput(output, context.rootDirectory).map((diagnostic) => ({
 			...diagnostic,
 			filePath: projectRelativePosix(context.rootDirectory, diagnostic.filePath),
 		}));
+		if (!context.files) return diagnostics;
+		const allowed = new Set(relativeTargets(context, language));
+		return diagnostics.filter((diagnostic) => allowed.has(diagnostic.filePath));
 	} catch {
 		return [];
 	}
 };
 
+const LANGUAGE_EXTENSIONS: Partial<Record<Language, ReadonlySet<string>>> = {
+	rust: new Set([".rs"]),
+	ruby: new Set([".rb"]),
+	php: new Set([".php"]),
+};
+
+const relativeTargets = (context: EngineContext, language: Language): string[] => {
+	const extensions = LANGUAGE_EXTENSIONS[language];
+	if (!extensions || !context.files) return [];
+	return [
+		...new Set(
+			context.files
+				.filter((filePath) => extensions.has(path.extname(filePath).toLowerCase()))
+				.map((filePath) => projectRelativePosix(context.rootDirectory, filePath))
+				.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")),
+		),
+	];
+};
+
 export const fixGenericFormatter = async (
-	rootDirectory: string,
+	context: EngineContext,
 	language: Language,
 ): Promise<void> => {
 	const config = FORMATTERS[language];
 	if (!config) return;
+	const scoped = relativeTargets(context, language);
+	if (context.files && scoped.length === 0) return;
 
-	const result = await runSubprocess(config.command, config.fixArgs, {
-		cwd: rootDirectory,
+	const args =
+		language === "php" && context.files
+			? ["fix", ...scoped]
+			: context.files
+				? [...config.fixArgs, ...scoped]
+				: config.fixArgs;
+
+	const result = await runSubprocess(config.command, args, {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 

--- a/src/engines/format/gofmt.ts
+++ b/src/engines/format/gofmt.ts
@@ -1,10 +1,27 @@
+import path from "node:path";
 import { relativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
 import type { Diagnostic, EngineContext } from "../types.js";
 
+const GO_EXTENSIONS = new Set([".go"]);
+
+const gofmtTargets = (context: EngineContext): string[] => {
+	if (!context.files) return [context.rootDirectory];
+	return [
+		...new Set(
+			context.files
+				.filter((filePath) => GO_EXTENSIONS.has(path.extname(filePath).toLowerCase()))
+				.map((filePath) => relativePosix(context.rootDirectory, filePath))
+				.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")),
+		),
+	];
+};
+
 export const runGofmt = async (context: EngineContext): Promise<Diagnostic[]> => {
+	const targets = gofmtTargets(context);
+	if (targets.length === 0) return [];
 	try {
-		const result = await runSubprocess("gofmt", ["-l", context.rootDirectory], {
+		const result = await runSubprocess("gofmt", ["-l", ...targets], {
 			cwd: context.rootDirectory,
 			timeout: 60000,
 		});
@@ -29,9 +46,11 @@ export const runGofmt = async (context: EngineContext): Promise<Diagnostic[]> =>
 	}
 };
 
-export const fixGofmt = async (rootDirectory: string): Promise<void> => {
-	const result = await runSubprocess("gofmt", ["-w", rootDirectory], {
-		cwd: rootDirectory,
+export const fixGofmt = async (context: EngineContext): Promise<void> => {
+	const targets = gofmtTargets(context);
+	if (targets.length === 0) return;
+	const result = await runSubprocess("gofmt", ["-w", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {

--- a/src/engines/format/ruff-format.ts
+++ b/src/engines/format/ruff-format.ts
@@ -47,10 +47,12 @@ const parseRuffFormatOutput = (output: string, rootDir: string): Diagnostic[] =>
 	return diagnostics;
 };
 
-export const fixRuffFormat = async (rootDirectory: string): Promise<void> => {
+export const fixRuffFormat = async (context: EngineContext): Promise<void> => {
+	const targets = context.files ? getPythonTargets(context) : [context.rootDirectory];
+	if (context.files && targets.length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(ruffBinary, ["format", rootDirectory], {
-		cwd: rootDirectory,
+	const result = await runSubprocess(ruffBinary, ["format", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {

--- a/src/engines/lint/generic.ts
+++ b/src/engines/lint/generic.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Language } from "../../utils/discover.js";
 import { projectRelativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
@@ -18,15 +19,26 @@ export const runGenericLinter = async (
 		default:
 			return [];
 	}
-	return diagnostics.map((diagnostic) => ({
+	const normalized = diagnostics.map((diagnostic) => ({
 		...diagnostic,
 		filePath: projectRelativePosix(context.rootDirectory, diagnostic.filePath),
 	}));
+	if (!context.files) return normalized;
+	const allowed = new Set(
+		context.files.map((filePath) => projectRelativePosix(context.rootDirectory, filePath)),
+	);
+	return normalized.filter((diagnostic) => allowed.has(diagnostic.filePath));
 };
 
-export const fixRubyLint = async (rootDirectory: string): Promise<void> => {
-	const result = await runSubprocess("rubocop", ["-a", "--except", "Layout"], {
-		cwd: rootDirectory,
+export const fixRubyLint = async (context: EngineContext): Promise<void> => {
+	const targets =
+		context.files
+			?.filter((filePath) => path.extname(filePath).toLowerCase() === ".rb")
+			.map((filePath) => projectRelativePosix(context.rootDirectory, filePath))
+			.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")) ?? [];
+	if (context.files && targets.length === 0) return;
+	const result = await runSubprocess("rubocop", ["-a", "--except", "Layout", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 

--- a/src/engines/lint/ruff.ts
+++ b/src/engines/lint/ruff.ts
@@ -48,10 +48,19 @@ export const runRuffLint = async (
 	}
 };
 
-export const fixRuffLint = async (rootDirectory: string): Promise<void> => {
+const ruffLintFixArgs = (context: EngineContext, unsafe: boolean): string[] => {
+	const targets = context.files ? getPythonTargets(context) : [context.rootDirectory];
+	const args = ["check", "--fix"];
+	if (unsafe) args.push("--unsafe-fixes");
+	args.push(...targets);
+	return args;
+};
+
+export const fixRuffLint = async (context: EngineContext): Promise<void> => {
+	if (context.files && getPythonTargets(context).length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(ruffBinary, ["check", "--fix", rootDirectory], {
-		cwd: rootDirectory,
+	const result = await runSubprocess(ruffBinary, ruffLintFixArgs(context, false), {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {
@@ -61,16 +70,13 @@ export const fixRuffLint = async (rootDirectory: string): Promise<void> => {
 	}
 };
 
-export const fixRuffLintForce = async (rootDirectory: string): Promise<void> => {
+export const fixRuffLintForce = async (context: EngineContext): Promise<void> => {
+	if (context.files && getPythonTargets(context).length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(
-		ruffBinary,
-		["check", "--fix", "--unsafe-fixes", rootDirectory],
-		{
-			cwd: rootDirectory,
-			timeout: 60000,
-		},
-	);
+	const result = await runSubprocess(ruffBinary, ruffLintFixArgs(context, true), {
+		cwd: context.rootDirectory,
+		timeout: 60000,
+	});
 	if (result.exitCode !== 0) {
 		throw new Error(
 			result.stderr || result.stdout || `ruff check --fix exited with code ${result.exitCode}`,

--- a/src/ui/command-reference-data.ts
+++ b/src/ui/command-reference-data.ts
@@ -42,6 +42,9 @@ const FIX_FLAGS = [
 	"-f, --force",
 	"--safe",
 	"--dry-run",
+	"--changes",
+	"--staged",
+	"--base <ref>",
 	"-p, --prompt",
 	...FIX_AGENT_FLAGS,
 ];

--- a/tests/ci-changes-base.test.ts
+++ b/tests/ci-changes-base.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
+import { isPathInFixScope } from "../src/commands/fix-scope.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
+import type { EngineContext } from "../src/engines/types.js";
 
 const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
 
@@ -75,5 +80,186 @@ describe("ci --changes --base", () => {
 		expect(res.status).not.toBe(0);
 		const parsed = JSON.parse(res.stdout) as { error?: string };
 		expect(parsed.error).toMatch(/does-not-exist/);
+	});
+});
+
+const UNUSED_IMPORT = 'import { leftover } from "./missing";\nexport const value = 1;\n';
+const FIXED_IMPORT = "export const value = 1;\n";
+
+const slopConfig = (): AislopConfig => ({
+	...DEFAULT_CONFIG,
+	engines: {
+		...DEFAULT_CONFIG.engines,
+		format: false,
+		lint: false,
+		"code-quality": false,
+		architecture: false,
+		security: false,
+		"ai-slop": true,
+	},
+	telemetry: { enabled: false },
+});
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+const posixRel = (root: string, rel: string): string =>
+	fs.readFileSync(path.join(root, ...rel.split("/")), "utf-8");
+
+describe("fix --changes --base", () => {
+	let tmpDir = "";
+	let baseSha = "";
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-"));
+		git(tmpDir, ["init"]);
+		git(tmpDir, ["config", "user.email", "test@example.com"]);
+		git(tmpDir, ["config", "user.name", "test"]);
+		git(tmpDir, ["config", "commit.gpgsign", "false"]);
+		write(tmpDir, "untouched.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "base", "--no-verify"]);
+		baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: tmpDir,
+			encoding: "utf8",
+		}).trim();
+		git(tmpDir, ["checkout", "-b", "feature"]);
+		write(tmpDir, "changed.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "feat", "--no-verify"]);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("does not rewrite files outside the selected change set", async () => {
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				changes: true,
+				base: baseSha,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("includes untracked files using the same semantics as scan --changes", async () => {
+		write(tmpDir, "fresh.ts", UNUSED_IMPORT);
+		write(tmpDir, "notes.txt", "leave me alone\n");
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				changes: true,
+				base: baseSha,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "fresh.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "notes.txt")).toBe("leave me alone\n");
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("fails when --changes and --staged are combined", async () => {
+		const result = await fixCommand(tmpDir, slopConfig(), {
+			verbose: false,
+			changes: true,
+			staged: true,
+			showHeader: false,
+		});
+		expect(result.exitCode).toBe(1);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(UNUSED_IMPORT);
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("fails when an explicit --base ref cannot be resolved", async () => {
+		const result = await fixCommand(tmpDir, slopConfig(), {
+			verbose: false,
+			changes: true,
+			base: "origin/does-not-exist",
+			showHeader: false,
+		});
+		expect(result.exitCode).toBe(1);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(UNUSED_IMPORT);
+	});
+});
+
+describe("fix --staged", () => {
+	let tmpDir = "";
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-staged-"));
+		git(tmpDir, ["init"]);
+		git(tmpDir, ["config", "user.email", "test@example.com"]);
+		git(tmpDir, ["config", "user.name", "test"]);
+		git(tmpDir, ["config", "commit.gpgsign", "false"]);
+		write(tmpDir, "committed.ts", FIXED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rewrites staged files only and leaves unstaged and untracked files alone", async () => {
+		write(tmpDir, "staged.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "staged.ts"]);
+		write(tmpDir, "unstaged.ts", UNUSED_IMPORT);
+		write(tmpDir, "committed.ts", UNUSED_IMPORT);
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				staged: true,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "staged.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "unstaged.ts")).toBe(UNUSED_IMPORT);
+		expect(posixRel(tmpDir, "committed.ts")).toBe(UNUSED_IMPORT);
+	});
+});
+
+describe("fix scope path normalization", () => {
+	it("treats OS-native and POSIX-relative paths as the same file", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-paths-"));
+		try {
+			const nativeFile = path.join(root, "src", "app.ts");
+			const context = {
+				rootDirectory: root,
+				languages: ["typescript"],
+				frameworks: ["none"],
+				files: [nativeFile],
+				installedTools: {},
+				config: {
+					quality: DEFAULT_CONFIG.quality,
+					security: DEFAULT_CONFIG.security,
+					lint: DEFAULT_CONFIG.lint,
+				},
+			} as EngineContext;
+			expect(isPathInFixScope(context, nativeFile)).toBe(true);
+			expect(isPathInFixScope(context, "src/app.ts")).toBe(true);
+			expect(isPathInFixScope(context, path.join(root, "src", "other.ts"))).toBe(false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -228,6 +228,9 @@ describe("cli ergonomics", () => {
 		expect(fix.stdout).toContain("Auto-fix findings or hand off to a coding agent");
 		expect(fix.stdout).toContain("--safe");
 		expect(fix.stdout).toContain("--dry-run");
+		expect(fix.stdout).toContain("--changes");
+		expect(fix.stdout).toContain("--staged");
+		expect(fix.stdout).toContain("--base <ref>");
 		expect(fix.stdout).toContain("--claude");
 		expect(fix.stdout).toContain("--codex");
 		expect(fix.stdout).toContain("--opencode");

--- a/tests/fix-safe-mode.test.ts
+++ b/tests/fix-safe-mode.test.ts
@@ -182,3 +182,59 @@ describe("fix --dry-run --safe", () => {
 		).toBe(statusBefore);
 	});
 });
+
+describe("fix --dry-run --changes", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("previews only the selected change set and still writes nothing", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-dry-run-changes-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		write(root, "untouched.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "base", "--no-verify"]);
+		const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: root,
+			encoding: "utf-8",
+		}).trim();
+		write(root, "changed.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "feat", "--no-verify"]);
+		const before = posixTree(root);
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: {
+				...DEFAULT_CONFIG.engines,
+				format: false,
+				lint: false,
+				"code-quality": false,
+				architecture: false,
+				security: false,
+				"ai-slop": true,
+			},
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, {
+				verbose: false,
+				dryRun: true,
+				changes: true,
+				base: baseSha,
+				showHeader: true,
+			}),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Scope");
+		expect(output).toContain("changed vs");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+	});
+});

--- a/tests/fix-scope-manifest.test.ts
+++ b/tests/fix-scope-manifest.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEngineContext } from "../src/commands/fix-context.js";
+import { scopeIncludesManifestWrites } from "../src/commands/fix-scope.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { EngineContext } from "../src/engines/types.js";
+
+let tmpDir: string;
+
+const contextFor = (files?: string[]): EngineContext =>
+	({
+		rootDirectory: tmpDir,
+		languages: ["typescript"],
+		frameworks: [],
+		files: files?.map((name) => path.join(tmpDir, name)),
+		installedTools: {},
+		config: {
+			quality: { maxFunctionLoc: 80, maxFileLoc: 400, maxNesting: 5, maxParams: 6 },
+			security: { audit: false, auditTimeout: 0 },
+		},
+	}) as unknown as EngineContext;
+
+const write = (name: string): void => fs.writeFileSync(path.join(tmpDir, name), "{}");
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-"));
+	write("package.json");
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("scopeIncludesManifestWrites", () => {
+	it("allows an unscoped fix", () => {
+		expect(scopeIncludesManifestWrites(contextFor())).toBe(true);
+	});
+
+	it("refuses when a lockfile is selected but the manifest the fixer rewrites is not", () => {
+		// The dependency fixers always rewrite package.json. Selecting only the lockfile
+		// used to pass the gate, letting a fix edit a file outside the chosen change set.
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["pnpm-lock.yaml", "src/app.ts"]))).toBe(false);
+	});
+
+	it("refuses when the manifest is selected but a lockfile it rewrites is not", () => {
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["package.json"]))).toBe(false);
+	});
+
+	it("allows when every file the fixer writes is selected", () => {
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["package.json", "pnpm-lock.yaml"]))).toBe(true);
+	});
+
+	it("ignores lockfiles the project does not have", () => {
+		expect(scopeIncludesManifestWrites(contextFor(["package.json"]))).toBe(true);
+	});
+});
+
+describe("manifest-only scopes keep project languages for dependency work", () => {
+	it("carries the project languages even when the selection has no source file", () => {
+		// detectSourceLanguages sees only package.json here and returns nothing, which used
+		// to make every dependency fixer skip a scope that explicitly selected the manifest.
+		const scopedProjectInfo = {
+			languages: [],
+			frameworks: [],
+			installedTools: {},
+		} as unknown as Parameters<typeof createEngineContext>[1];
+
+		const context = createEngineContext(tmpDir, scopedProjectInfo, DEFAULT_CONFIG, {
+			scope: {
+				files: [path.join(tmpDir, "package.json")],
+				testFiles: [],
+				projectFiles: [],
+				dependencyAuditFiles: [path.join(tmpDir, "package.json")],
+				dependencyAuditScope: "scoped",
+				scopeLabel: "changed files",
+			} as unknown as Parameters<typeof createEngineContext>[3]["scope"],
+			dependencyAuditLanguages: ["typescript"],
+		});
+
+		expect(context.languages).toEqual([]);
+		expect(context.dependencyAuditLanguages).toEqual(["typescript"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds `aislop fix --changes`, `aislop fix --changes --base <ref>`, and `aislop fix --staged`. File selection reuses scan's resolver (`collectScanFileScope`, `--base` validation, untracked/renamed ACMR semantics). `--changes` and `--staged` are mutually exclusive. Scoped runs never fall back to a full-project rewrite: `EngineContext.files` is set even when the change set is empty.

Formatters that cannot honour an explicit file list (`cargo fmt`, `dotnet format`) are skipped with a reason. Ruff, gofmt, biome, oxlint, ruby, and php receive the scoped file list. Dependency mutation (knip unused deps, audit, expo) runs only when a manifest or lockfile is in the selected scope. The post-fix verification scan uses the same files. `aislop fix --dry-run` honours the same flags.

Stacks on #373 (`fix --dry-run`). Until that merges, this PR also contains that commit.

## Type of change

- [x] New feature (adds functionality)

## Acceptance criteria

- [x] `--changes`, `--staged`, and `--base` follow the same resolution and validation rules as scan.
- [x] `--changes` and `--staged` are mutually exclusive.
- [x] No source file outside the selected scope is modified.
- [x] Project-wide formatters or fixers that cannot honour an explicit file scope are skipped with a clear explanation.
- [x] Dependency mutation steps run only when a relevant manifest or lockfile is inside the selected scope.
- [x] Untracked changed files and renamed files follow existing scan semantics.
- [x] The final verification scan uses the same bounded scope.
- [x] Tests cover Linux, macOS-compatible, and Windows-normalized paths.
- [x] Dry-run from #373 honours the same flags.

## Validation

```bash
pnpm vitest run tests/git.test.ts tests/ci-changes-base.test.ts tests/fix-safe-mode.test.ts
pnpm typecheck
pnpm scan --exclude tools/oss-benchmark.mjs
```

- focused suites: pass (changed, staged, untracked, untouched, invalid base, mutual exclusion, path normalization, dry-run + `--changes`)
- `pnpm typecheck`: pass
- `pnpm test`: 200 files, 2081 tests pass
- self-scan of this change: 100/100, 0 findings

Fixes #321