### PR TITLE
feat(scan): classify changed-line vs existing-file context

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -11,7 +11,9 @@ import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
 import { renderDisplayRows } from "../ui/display.js";
 import { renderHeader } from "../ui/header.js";
 import { log } from "../ui/logger.js";
+import { applyChangeContext } from "../utils/change-context.js";
 import { detectSourceLanguages, discoverProject, type Language } from "../utils/discover.js";
+import { getChangedLineMap } from "../utils/git.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
@@ -165,10 +167,22 @@ const runScanBody = async (
 		...result,
 		diagnostics: applyRuleSeverities(result.diagnostics, config.rules),
 	}));
-	const { results, suppressedCount } = applySuppressions(severityAdjusted, resolvedDir);
+	const { results: unannotated, suppressedCount } = applySuppressions(
+		severityAdjusted,
+		resolvedDir,
+	);
 	if (suppressedCount > 0 && !machineOutput) {
 		log.muted(`Suppressed ${suppressedCount} finding(s) via aislop-ignore directives`);
 	}
+
+	const classifyChanges = options.changes && !options.staged;
+	const changeMap = classifyChanges ? getChangedLineMap(resolvedDir, options.base) : null;
+	const results = changeMap
+		? unannotated.map((result) => ({
+				...result,
+				diagnostics: applyChangeContext(result.diagnostics, changeMap, resolvedDir),
+			}))
+		: unannotated;
 
 	const allDiagnostics = results.flatMap((r) => r.diagnostics);
 	const elapsedMs = performance.now() - startTime;

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -10,6 +10,8 @@ export type EngineName =
 	| "architecture"
 	| "security";
 
+export type ChangeContext = "changed-line" | "existing-file-context" | "unknown";
+
 export interface Diagnostic {
 	filePath: string;
 	engine: EngineName;
@@ -22,6 +24,7 @@ export interface Diagnostic {
 	category: string;
 	fixable: boolean;
 	detail?: string;
+	changeContext?: ChangeContext;
 }
 
 export interface EngineResult {

--- a/src/output/sarif.ts
+++ b/src/output/sarif.ts
@@ -27,6 +27,7 @@ interface SarifResult {
 			region: { startLine: number; startColumn: number };
 		};
 	}>;
+	properties?: { changeContext: string };
 }
 
 interface SarifLog {
@@ -88,6 +89,7 @@ export const buildSarifLog = (results: EngineResult[]): SarifLog => {
 				},
 			},
 		],
+		...(d.changeContext ? { properties: { changeContext: d.changeContext } } : {}),
 	}));
 
 	return {

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -1,8 +1,9 @@
-import type { Diagnostic, EngineResult } from "../engines/types.js";
+import type { ChangeContext, Diagnostic, EngineResult } from "../engines/types.js";
 import { highlightAislop } from "../ui/brand.js";
 import { log } from "../ui/logger.js";
 import { symbols } from "../ui/symbols.js";
 import { style, theme } from "../ui/theme.js";
+import { changeContextOrder } from "../utils/change-context.js";
 import { getEngineLabel } from "./engine-info.js";
 
 const groupBy = <T>(items: T[], key: (item: T) => string): Map<string, T[]> => {
@@ -146,8 +147,13 @@ const renderHiddenFooter = (
 	lines.push("");
 };
 
-export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): string => {
-	const lines: string[] = [];
+const CHANGE_CONTEXT_HEADING: Record<ChangeContext, string> = {
+	"changed-line": "Changed lines",
+	"existing-file-context": "Existing file context",
+	unknown: "Unclassified",
+};
+
+const renderEngineGroups = (diagnostics: Diagnostic[], verbose: boolean, lines: string[]): void => {
 	const byEngine = groupBy(diagnostics, (d) => d.engine);
 
 	for (const [engine, engineDiags] of byEngine) {
@@ -175,6 +181,34 @@ export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): 
 		}
 
 		if (sorted.length > maxRules) renderHiddenFooter(sorted, maxRules, lines);
+	}
+};
+
+export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): string => {
+	const lines: string[] = [];
+	const classified = diagnostics.some((diagnostic) => diagnostic.changeContext);
+	if (!classified) {
+		renderEngineGroups(diagnostics, verbose, lines);
+		return `${lines.join("\n")}\n`;
+	}
+
+	const partitions = new Map<ChangeContext, Diagnostic[]>();
+	for (const diagnostic of [...diagnostics].sort(
+		(left, right) =>
+			changeContextOrder(left.changeContext) - changeContextOrder(right.changeContext),
+	)) {
+		const key = diagnostic.changeContext ?? "unknown";
+		const group = partitions.get(key) ?? [];
+		group.push(diagnostic);
+		partitions.set(key, group);
+	}
+
+	const order: ChangeContext[] = ["changed-line", "existing-file-context", "unknown"];
+	for (const key of order) {
+		const group = partitions.get(key);
+		if (!group || group.length === 0) continue;
+		lines.push(`  ${style(theme, "section", CHANGE_CONTEXT_HEADING[key])}`);
+		renderEngineGroups(group, verbose, lines);
 	}
 
 	return `${lines.join("\n")}\n`;

--- a/src/utils/change-context.ts
+++ b/src/utils/change-context.ts
@@ -1,0 +1,98 @@
+import type { ChangeContext, Diagnostic } from "../engines/types.js";
+import { projectRelativePosix, toPosix } from "./paths.js";
+
+export type ChangedLines =
+	| { readonly kind: "all" }
+	| { readonly kind: "hunks"; readonly ranges: ReadonlyArray<{ start: number; end: number }> };
+
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+const stripDiffPrefix = (filePath: string): string => {
+	if (filePath === "/dev/null") return filePath;
+	return filePath.replace(/^[ab]\//, "");
+};
+
+const parseHunkRange = (
+	startText: string,
+	countText: string | undefined,
+): { start: number; end: number } | null => {
+	const start = Number(startText);
+	const count = countText === undefined ? 1 : Number(countText);
+	if (!Number.isFinite(start) || !Number.isFinite(count) || count <= 0) return null;
+	return { start, end: start + count - 1 };
+};
+
+export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> => {
+	const byFile = new Map<string, { start: number; end: number }[]>();
+	let current: string | null = null;
+
+	for (const raw of diff.split(/\r?\n/)) {
+		if (raw.startsWith("rename to ")) {
+			current = toPosix(raw.slice("rename to ".length).trim());
+			if (current && !byFile.has(current)) byFile.set(current, []);
+			continue;
+		}
+		if (raw.startsWith("+++ ")) {
+			const name = stripDiffPrefix(raw.slice(4).trim());
+			current = name === "/dev/null" ? null : toPosix(name);
+			if (current && !byFile.has(current)) byFile.set(current, []);
+			continue;
+		}
+		if (!current) continue;
+		const match = HUNK_RE.exec(raw);
+		if (!match) continue;
+		const range = parseHunkRange(match[3], match[4]);
+		if (!range) continue;
+		const ranges = byFile.get(current);
+		if (ranges) ranges.push(range);
+	}
+
+	const result = new Map<string, ChangedLines>();
+	for (const [filePath, ranges] of byFile) {
+		result.set(filePath, { kind: "hunks", ranges });
+	}
+	return result;
+};
+
+const lookupChangedLines = (
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+	filePath: string,
+): ChangedLines | undefined => {
+	const slashPath = filePath.split("\\").join("/");
+	const relative = projectRelativePosix(rootDirectory, slashPath);
+	return map.get(relative) ?? map.get(toPosix(slashPath)) ?? map.get(slashPath);
+};
+
+export const classifyChangeContext = (
+	diagnostic: Diagnostic,
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+): ChangeContext => {
+	if (diagnostic.line <= 0) return "unknown";
+	const entry = lookupChangedLines(map, rootDirectory, diagnostic.filePath);
+	if (!entry) return "unknown";
+	if (entry.kind === "all") return "changed-line";
+	if (
+		entry.ranges.some((range) => diagnostic.line >= range.start && diagnostic.line <= range.end)
+	) {
+		return "changed-line";
+	}
+	return "existing-file-context";
+};
+
+export const applyChangeContext = (
+	diagnostics: Diagnostic[],
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+): Diagnostic[] =>
+	diagnostics.map((diagnostic) => ({
+		...diagnostic,
+		changeContext: classifyChangeContext(diagnostic, map, rootDirectory),
+	}));
+
+export const changeContextOrder = (context: ChangeContext | undefined): number => {
+	if (context === "changed-line") return 0;
+	if (context === "existing-file-context") return 1;
+	return 2;
+};

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { type ChangedLines, parseUnifiedDiffHunks } from "./change-context.js";
+import { projectRelativePosix } from "./paths.js";
 
 const MAX_BUFFER = 50 * 1024 * 1024;
 
@@ -52,4 +54,28 @@ export const getStagedFiles = (cwd: string): string[] => {
 		.split("\n")
 		.filter((f) => f.length > 0)
 		.map((f) => path.resolve(cwd, f));
+};
+
+const listUntrackedFiles = (cwd: string): string[] => {
+	const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: MAX_BUFFER,
+	});
+	if (untracked.error || untracked.status !== 0) return [];
+	return untracked.stdout.split("\n").filter((line) => line.length > 0);
+};
+
+export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
+	const baseRef = base ?? "HEAD";
+	const diff = spawnSync("git", ["diff", "-U0", "--diff-filter=ACMR", baseRef], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: MAX_BUFFER,
+	});
+	const map = !diff.error && diff.status === 0 ? parseUnifiedDiffHunks(diff.stdout) : new Map();
+	for (const name of listUntrackedFiles(cwd)) {
+		map.set(projectRelativePosix(cwd, path.resolve(cwd, name)), { kind: "all" });
+	}
+	return map;
 };

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -17,7 +17,7 @@ export const baseRefExists = (cwd: string, ref: string): boolean => {
 
 export const getChangedFiles = (cwd: string, base?: string): string[] => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--name-only", "--diff-filter=ACMR", baseRef], {
+	const diff = spawnSync("git", ["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,
@@ -44,7 +44,7 @@ export const getChangedFiles = (cwd: string, base?: string): string[] => {
 };
 
 export const getStagedFiles = (cwd: string): string[] => {
-	const result = spawnSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMR"], {
+	const result = spawnSync("git", ["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,
@@ -68,7 +68,7 @@ const listUntrackedFiles = (cwd: string): string[] => {
 
 export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "-U0", "--diff-filter=ACMR", baseRef], {
+	const diff = spawnSync("git", ["diff", "--no-color", "-U0", "--diff-filter=ACMR", baseRef], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,

--- a/tests/ci-changes-base.test.ts
+++ b/tests/ci-changes-base.test.ts
@@ -76,4 +76,32 @@ describe("ci --changes --base", () => {
 		const parsed = JSON.parse(res.stdout) as { error?: string };
 		expect(parsed.error).toMatch(/does-not-exist/);
 	});
+
+	it("classifies new-line findings vs existing-file context without hiding either", () => {
+		write(tmpDir, "tainted.ts", `${SECRET}export const extra = 1 as any;\n`);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "edit", "--no-verify"]);
+		const scoped = runCli(["scan", tmpDir, "--changes", "--base", baseSha, "--json"]);
+		const parsed = JSON.parse(scoped.stdout) as {
+			diagnostics?: Array<{ rule: string; line: number; changeContext?: string }>;
+		};
+		const byRule = new Map((parsed.diagnostics ?? []).map((d) => [d.rule, d]));
+		expect(byRule.get("security/hardcoded-secret")?.changeContext).toBe("existing-file-context");
+		expect(byRule.get("ai-slop/unsafe-type-assertion")?.changeContext).toBe("changed-line");
+	});
+
+	it("does not classify full scans or staged scans", () => {
+		write(tmpDir, "clean.ts", `${CLEAN}export const extra = 1 as any;\n`);
+		git(tmpDir, ["add", "clean.ts"]);
+		const full = runCli(["scan", tmpDir, "--json"]);
+		const staged = runCli(["scan", tmpDir, "--staged", "--json"]);
+		const fullDiag = (
+			JSON.parse(full.stdout) as { diagnostics?: Array<{ changeContext?: string }> }
+		).diagnostics?.[0];
+		const stagedDiag = (
+			JSON.parse(staged.stdout) as { diagnostics?: Array<{ changeContext?: string }> }
+		).diagnostics?.[0];
+		expect(fullDiag?.changeContext).toBeUndefined();
+		expect(stagedDiag?.changeContext).toBeUndefined();
+	});
 });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getChangedFiles, getStagedFiles } from "../src/utils/git.js";
+import type { Diagnostic } from "../src/engines/types.js";
+import { classifyChangeContext, parseUnifiedDiffHunks } from "../src/utils/change-context.js";
+import { getChangedFiles, getChangedLineMap, getStagedFiles } from "../src/utils/git.js";
 
 const git = (cwd: string, args: string[]) => {
 	execFileSync("git", args, { cwd, stdio: "ignore" });
@@ -114,5 +116,82 @@ describe("getStagedFiles", () => {
 		expect(files).toContain(path.join(tmpDir, "staged.ts"));
 		expect(files).not.toContain(path.join(tmpDir, "base.ts"));
 		expect(files).not.toContain(path.join(tmpDir, "untracked.ts"));
+	});
+});
+
+const sampleDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+	filePath: "src/app.ts",
+	engine: "ai-slop",
+	rule: "ai-slop/unsafe-type-assertion",
+	severity: "warning",
+	message: "unsafe",
+	help: "",
+	line: 2,
+	column: 1,
+	category: "types",
+	fixable: false,
+	...overrides,
+});
+
+describe("changed-line hunk classification", () => {
+	it("classifies added and modified new-file lines, deleted-only hunks, and file-level findings", () => {
+		const diff = [
+			"diff --git a/src/app.ts b/src/app.ts",
+			"--- a/src/app.ts",
+			"+++ b/src/app.ts",
+			"@@ -1,1 +1,1 @@",
+			"-export const a = 1;",
+			"+export const a = 2;",
+			"@@ -10,2 +10,0 @@",
+			"-gone",
+			"-also",
+			"diff --git a/src/new.ts b/src/new.ts",
+			"new file mode 100644",
+			"--- /dev/null",
+			"+++ b/src/new.ts",
+			"@@ -0,0 +1,2 @@",
+			"+one",
+			"+two",
+		].join("\n");
+		const map = parseUnifiedDiffHunks(diff);
+		const root = "/repo";
+
+		expect(classifyChangeContext(sampleDiagnostic({ line: 1 }), map, root)).toBe("changed-line");
+		expect(classifyChangeContext(sampleDiagnostic({ line: 4 }), map, root)).toBe(
+			"existing-file-context",
+		);
+		expect(classifyChangeContext(sampleDiagnostic({ line: 0 }), map, root)).toBe("unknown");
+		expect(
+			classifyChangeContext(sampleDiagnostic({ filePath: "src/new.ts", line: 2 }), map, root),
+		).toBe("changed-line");
+		expect(
+			classifyChangeContext(sampleDiagnostic({ filePath: "src\\new.ts", line: 1 }), map, root),
+		).toBe("changed-line");
+	});
+
+	it("maps renamed files to the new path and treats untracked files as whole-file changes", () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-hunks-"));
+		try {
+			git(tmpDir, ["init"]);
+			git(tmpDir, ["config", "user.email", "test@example.com"]);
+			git(tmpDir, ["config", "user.name", "test"]);
+			git(tmpDir, ["config", "commit.gpgsign", "false"]);
+			write(tmpDir, "old.ts", "export const value = 1;\nexport const keep = 2;\n");
+			git(tmpDir, ["add", "old.ts"]);
+			git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+			git(tmpDir, ["mv", "old.ts", "renamed.ts"]);
+			write(tmpDir, "fresh.ts", "export const fresh = 1;\n");
+			const map = getChangedLineMap(tmpDir);
+			expect(map.get("renamed.ts")?.kind).toBe("hunks");
+			expect(map.get("fresh.ts")).toEqual({ kind: "all" });
+			expect(
+				classifyChangeContext(sampleDiagnostic({ filePath: "renamed.ts", line: 1 }), map, tmpDir),
+			).toBe("existing-file-context");
+			expect(
+				classifyChangeContext(sampleDiagnostic({ filePath: "fresh.ts", line: 1 }), map, tmpDir),
+			).toBe("changed-line");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -169,6 +169,30 @@ describe("changed-line hunk classification", () => {
 		).toBe("changed-line");
 	});
 
+	it("parses hunks when the user has git colour forced on", () => {
+		// color.ui=always puts ANSI escapes ahead of the +++ and @@ markers, which hides
+		// every file and range from the hunk parser.
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-color-"));
+		try {
+			git(tmpDir, ["init"]);
+			git(tmpDir, ["config", "user.email", "test@example.com"]);
+			git(tmpDir, ["config", "user.name", "test"]);
+			git(tmpDir, ["config", "commit.gpgsign", "false"]);
+			git(tmpDir, ["config", "color.ui", "always"]);
+			git(tmpDir, ["config", "color.diff", "always"]);
+			write(tmpDir, "app.ts", "export const a = 1;\nexport const b = 2;\n");
+			git(tmpDir, ["add", "app.ts"]);
+			git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+			write(tmpDir, "app.ts", "export const a = 1;\nexport const b = 3;\n");
+
+			const map = getChangedLineMap(tmpDir);
+
+			expect(map.get("app.ts")?.kind).toBe("hunks");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("maps renamed files to the new path and treats untracked files as whole-file changes", () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-hunks-"));
 		try {

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -45,4 +45,37 @@ describe("terminal rendering", () => {
 		expect(output).toContain("src/example-4.ts:4:1");
 		expect(output).not.toContain("more location(s)");
 	});
+
+	it("lists changed-line findings before existing-file-context and still shows all in verbose mode", () => {
+		const output = renderDiagnostics(
+			[
+				createDiagnostic({
+					filePath: "src/old.ts",
+					line: 4,
+					message: "existing finding",
+					changeContext: "existing-file-context",
+				}),
+				createDiagnostic({
+					filePath: "src/new.ts",
+					line: 1,
+					message: "new finding",
+					changeContext: "changed-line",
+				}),
+				createDiagnostic({
+					filePath: "src/file.ts",
+					line: 0,
+					message: "file-level finding",
+					changeContext: "unknown",
+				}),
+			],
+			true,
+		);
+
+		expect(output).toContain("Changed lines");
+		expect(output).toContain("Existing file context");
+		expect(output).toContain("Unclassified");
+		expect(output.indexOf("Changed lines")).toBeLessThan(output.indexOf("Existing file context"));
+		expect(output.indexOf("new finding")).toBeLessThan(output.indexOf("existing finding"));
+		expect(output).toContain("file-level finding");
+	});
 });

--- a/tests/output/json.test.ts
+++ b/tests/output/json.test.ts
@@ -75,6 +75,28 @@ describe("json output", () => {
 		expect(out.findingAssessment.byKind["confirmed-defect"]).toBe(1);
 	});
 
+	it("exposes stable changeContext metadata when present", () => {
+		const out = buildJsonOutput(
+			[result([diagnostic({ changeContext: "changed-line" })])],
+			{ score: 50, label: "Critical" },
+			10,
+			10,
+			scoreable,
+		);
+		expect(out.diagnostics[0].changeContext).toBe("changed-line");
+	});
+
+	it("omits changeContext when the scan did not classify diffs", () => {
+		const out = buildJsonOutput(
+			[result([diagnostic()])],
+			{ score: 50, label: "Critical" },
+			10,
+			10,
+			scoreable,
+		);
+		expect(out.diagnostics[0].changeContext).toBeUndefined();
+	});
+
 	it("includes advisory score impact metadata for soft config warnings", () => {
 		const out = buildJsonOutput(
 			[

--- a/tests/output/sarif.test.ts
+++ b/tests/output/sarif.test.ts
@@ -62,6 +62,20 @@ describe("buildSarifLog", () => {
 		expect(log.runs[0]?.results[2]?.ruleIndex).toBe(1);
 	});
 
+	it("exposes changeContext on result properties when classified", () => {
+		const log = buildSarifLog([
+			createResult([createDiagnostic({ changeContext: "existing-file-context" })]),
+		]);
+		expect(log.runs[0]?.results[0]?.properties).toEqual({
+			changeContext: "existing-file-context",
+		});
+	});
+
+	it("omits result properties when changeContext is absent", () => {
+		const log = buildSarifLog([createResult([createDiagnostic()])]);
+		expect(log.runs[0]?.results[0]?.properties).toBeUndefined();
+	});
+
 	it("emits a 1-based physical location", () => {
 		const log = buildSarifLog([
 			createResult([createDiagnostic({ filePath: "src/a/b.ts", line: 0, column: 0 })]),


### PR DESCRIPTION
## What does this PR do?

When `aislop scan --changes` has a resolvable base, each diagnostic is classified from the same diff hunks `--changes` uses:

- `changed-line` if it overlaps an added or modified line
- `existing-file-context` if it is in a changed file but outside those hunks
- `unknown` for file-level findings (`line <= 0`) or anything that cannot be classified safely

Terminal output lists changed-line findings first, then existing-file context, then unclassified. Verbose still shows every finding. JSON adds `changeContext` on each diagnostic; SARIF adds `properties.changeContext`. Full scans, staged scans, and scans without classification keep current behaviour. Detectors and scoring are unchanged. There is no blame and no hiding.

## Type of change

- [x] New feature (adds functionality)

## Acceptance criteria

- [x] Diff hunks are derived from the resolved base used by `--changes`.
- [x] Line-based diagnostics are classified as `changed-line` or `existing-file-context`.
- [x] Diagnostics that cannot be classified safely use `unknown`; the CLI does not label them as newly introduced.
- [x] Default terminal output presents changed-line findings before existing-file context.
- [x] Verbose output still exposes all findings.
- [x] JSON and SARIF include stable change-context metadata.
- [x] Full scans, staged scans, and scans without a resolvable base retain their current behaviour.
- [x] Paths remain project-relative and work on Linux, macOS, and Windows.

## Validation

```bash
pnpm vitest run tests/git.test.ts tests/ci-changes-base.test.ts tests/output
pnpm typecheck
pnpm scan --exclude tools/oss-benchmark.mjs
```

Covered: added lines, modified lines, deleted-only hunks, file-level diagnostics, renamed files, untracked whole-file, Windows path separators.

- focused suites: pass
- `pnpm typecheck`: pass
- `pnpm test`: 200 files, 2073 tests pass
- self-scan: 100/100, 0 findings

Fixes #318