### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## 0.16.0 (2026-08-30)
+
+Scoping release. `fix` and `scan` can now be pointed at what changed rather than the whole tree, and `fix` can show what it would do before it does it.
+
+### Added
+
+- **`aislop fix --dry-run`.** Prints the planned fix steps, including the ones that will be skipped and why, without writing anything.
+- **`aislop fix --changes`, `--staged`, and `--base <ref>`.** Restricts fixes to changed or staged files, matching the flags `scan` already accepted. `--base` sets the diff base, defaulting to `HEAD`.
+- **Changed-line context on findings.** Diagnostics are classified as changed-line or existing-file context, so a scoped run separates what a change introduced from what it merely sits next to. Surfaced in terminal, JSON, and SARIF output.
+
+### Fixed
+
+- **Dependency fixes stay inside the selected scope.** A scope holding a lockfile and a source file, but not `package.json`, previously still ran the unused-dependency fixer, which always rewrites `package.json`. Fixes can no longer touch a file outside the selection. The force audit and Expo alignment steps shared the same gap.
+- **Dependency-only scopes work.** Selecting just a manifest detected no source language, so every dependency fixer skipped a scope that explicitly asked for it.
+- **`--dry-run` no longer deletes a same-named file.** The dotnet format report was written into the project root and removed on every run, destroying a user-owned `.aislop-dotnet-format.json`. It now lives outside the tree, which fixes the non-preview path too.
+- **C# and C/C++ formatters appear in the dry-run plan** instead of being omitted from the skipped-step list.
+- **Changed-line detection survives forced git colour.** With `color.ui=always`, `git diff` emitted ANSI escapes ahead of the hunk markers, so every diagnostic silently fell back to unknown context.
+
+### Internal
+
+- Dependency bumps: `@biomejs/biome` 2.5.10, `vitest` 4.1.11, `@types/node` 26.4.0, `expo-doctor` 1.20.3, `github/codeql-action` 4.37.9.
+
 ## 0.15.0 (2026-08-26)
 
 Calibration release. Scores now describe how code is written rather than how much of it there is, and three rules that fired on ordinary hand-written code have been corrected. **Every score moves in this release**, most of them upward. Badges, CI gates, and stored scans will all shift; if you gate CI on a threshold, re-baseline after upgrading.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 10 language targets (TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP, C#, C/C++). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump and changelog.

Minor, not patch: three new user-facing flags plus a new finding classification. Unlike 0.15.0 there is **no scoring change**, so existing badges and CI thresholds are unaffected.

## What is in it

**Added**
- `fix --dry-run`, printing planned and skipped steps without writing
- `fix --changes` / `--staged` / `--base <ref>`, matching what `scan` already took
- changed-line vs existing-file classification on findings, in terminal, JSON and SARIF

**Fixed** (all four from the Codex review on the feature PRs)
- dependency fixes no longer write `package.json` when it is outside the selected scope
- dependency-only scopes work instead of silently skipping every fixer
- the dotnet report no longer deletes a user-owned `.aislop-dotnet-format.json`
- C#/C++ formatters appear in the dry-run plan
- changed-line detection survives `color.ui=always`

## Verification

`--version` reports 0.16.0, typecheck clean, 2098 tests, self-scan 100/100, `npm pack --dry-run` produces `aislop-0.16.0.tgz` with all 32 files.