### PR TITLE
Release v0.16.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## 0.16.0 (2026-08-30)
+
+Scoping release. `fix` and `scan` can now be pointed at what changed rather than the whole tree, and `fix` can show what it would do before it does it.
+
+### Added
+
+- **`aislop fix --dry-run`.** Prints the planned fix steps, including the ones that will be skipped and why, without writing anything.
+- **`aislop fix --changes`, `--staged`, and `--base <ref>`.** Restricts fixes to changed or staged files, matching the flags `scan` already accepted. `--base` sets the diff base, defaulting to `HEAD`.
+- **Changed-line context on findings.** Diagnostics are classified as changed-line or existing-file context, so a scoped run separates what a change introduced from what it merely sits next to. Surfaced in terminal, JSON, and SARIF output.
+
+### Fixed
+
+- **Dependency fixes stay inside the selected scope.** A scope holding a lockfile and a source file, but not `package.json`, previously still ran the unused-dependency fixer, which always rewrites `package.json`. Fixes can no longer touch a file outside the selection. The force audit and Expo alignment steps shared the same gap.
+- **Dependency-only scopes work.** Selecting just a manifest detected no source language, so every dependency fixer skipped a scope that explicitly asked for it.
+- **`--dry-run` no longer deletes a same-named file.** The dotnet format report was written into the project root and removed on every run, destroying a user-owned `.aislop-dotnet-format.json`. It now lives outside the tree, which fixes the non-preview path too.
+- **C# and C/C++ formatters appear in the dry-run plan** instead of being omitted from the skipped-step list.
+- **Changed-line detection survives forced git colour.** With `color.ui=always`, `git diff` emitted ANSI escapes ahead of the hunk markers, so every diagnostic silently fell back to unknown context.
+
+### Internal
+
+- Dependency bumps: `@biomejs/biome` 2.5.10, `vitest` 4.1.11, `@types/node` 26.4.0, `expo-doctor` 1.20.3, `github/codeql-action` 4.37.9.
+
 ## 0.15.0 (2026-08-26)
 
 Calibration release. Scores now describe how code is written rather than how much of it there is, and three rules that fired on ordinary hand-written code have been corrected. **Every score moves in this release**, most of them upward. Badges, CI gates, and stored scans will all shift; if you gate CI on a threshold, re-baseline after upgrading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Scoping release. `fix` and `scan` can now be pointed at what changed rather than
 
 ### Added
 
-- **`aislop fix --dry-run`.** Prints the planned fix steps, including the ones that will be skipped and why, without writing anything.
+- **`aislop fix --dry-run`.** Prints the planned fix steps, including the ones that will be skipped and why, without writing anything. It cannot be combined with an agent handoff or `--prompt`; that combination is rejected rather than silently ignored.
 - **`aislop fix --changes`, `--staged`, and `--base <ref>`.** Restricts fixes to changed or staged files, matching the flags `scan` already accepted. `--base` sets the diff base, defaulting to `HEAD`.
 - **Changed-line context on findings.** Diagnostics are classified as changed-line or existing-file context, so a scoped run separates what a change introduced from what it merely sits next to. Surfaced in terminal, JSON, and SARIF output.
 
@@ -23,6 +23,11 @@ Scoping release. `fix` and `scan` can now be pointed at what changed rather than
 - **`--dry-run` no longer deletes a same-named file.** The dotnet format report was written into the project root and removed on every run, destroying a user-owned `.aislop-dotnet-format.json`. It now lives outside the tree, which fixes the non-preview path too.
 - **C# and C/C++ formatters appear in the dry-run plan** instead of being omitted from the skipped-step list.
 - **Changed-line detection survives forced git colour.** With `color.ui=always`, `git diff` emitted ANSI escapes ahead of the hunk markers, so every diagnostic silently fell back to unknown context.
+- **Scoped `fix` no longer rewrites test files.** A scoped run merged test files into the fixer's file list, so `fix --changes` edited a changed test file that a plain `fix` leaves alone.
+- **Scoped `fix` and `scan` agree on the score.** `fix` measured finding density against the selection while `scan` measured it against the project, so the same scope reported different numbers.
+- **Changed-line detection survives an external differ and diff-shaped content.** `git diff` now runs with `--no-ext-diff`, and a header is only recognised outside a hunk body, so an added line beginning `++ ` can no longer be read as a new file and swallow the hunks that follow it.
+- **`fix` respects `CI=true`.** Only `CI=1` was honoured, so spinner escape sequences reached the logs on GitHub Actions, GitLab and CircleCI.
+- **The agent TUI elapsed time advances.** It was derived from the clock during render with nothing scheduling a repaint, so it sat stale until an unrelated update happened to redraw the sidebar.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The deterministic layer beneath [`aislop agent`](#run-a-local-repair-agent): aut
 
 ```bash
 aislop fix                 # auto-fixes
+aislop fix --dry-run       # preview planned steps without writing files
 aislop fix -d              # detailed fix progress
 aislop fix --safe          # only reversible fixes (imports, comment removal, safe formatters)
 aislop fix -f              # aggressive: deps, unused files

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ The deterministic layer beneath [`aislop agent`](#run-a-local-repair-agent): aut
 ```bash
 aislop fix                 # auto-fixes
 aislop fix --dry-run       # preview planned steps without writing files
+aislop fix --changes       # only rewrite files changed vs HEAD
+aislop fix --staged        # only rewrite staged files
 aislop fix -d              # detailed fix progress
 aislop fix --safe          # only reversible fixes (imports, comment removal, safe formatters)
 aislop fix -f              # aggressive: deps, unused files

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,6 +91,9 @@ Use `--changes --base origin/<target>` to gate a pull request on only the files 
 | `-f, --force` | Run aggressive fixes: dependency audit, framework alignment, unused file removal |
 | `--safe` | Only apply reversible fixes |
 | `--dry-run` | Print planned fix steps, eligible findings, and skipped steps without writing files |
+| `--changes` | Only fix changed files (defaults to diffing `HEAD`) |
+| `--base <ref>` | Diff base for `--changes`, e.g. `origin/main` (default `HEAD`) |
+| `--staged` | Only fix staged files |
 | `-p, --prompt` | Print an agent-ready prompt for remaining issues |
 
 Agent handoff flags: `--claude`, `--codex`, `--cursor`, `--windsurf`, `--vscode`, `--amp`, `--antigravity`, `--deep-agents`, `--gemini`, `--kimi`, `--opencode`, `--warp`, `--aider`, `--goose`, `--pi`, `--crush`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -90,6 +90,7 @@ Use `--changes --base origin/<target>` to gate a pull request on only the files 
 | `-d, --verbose` | Show detailed fix progress |
 | `-f, --force` | Run aggressive fixes: dependency audit, framework alignment, unused file removal |
 | `--safe` | Only apply reversible fixes |
+| `--dry-run` | Print planned fix steps, eligible findings, and skipped steps without writing files |
 | `-p, --prompt` | Print an agent-ready prompt for remaining issues |
 
 Agent handoff flags: `--claude`, `--codex`, `--cursor`, `--windsurf`, `--vscode`, `--amp`, `--antigravity`, `--deep-agents`, `--gemini`, `--kimi`, `--opencode`, `--warp`, `--aider`, `--goose`, `--pi`, `--crush`.
@@ -247,6 +248,7 @@ aislop scan --sarif
 
 # Fix
 aislop fix
+aislop fix --dry-run
 aislop fix --safe
 aislop fix -f
 aislop fix --claude

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "adm-zip": "^0.6.0",
     "commander": "^14.0.3",
-    "expo-doctor": "^1.20.1",
+    "expo-doctor": "^1.20.3",
     "ink": "^7.1.1",
     "ink-select-input": "^6.2.0",
     "knip": "^6.32.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "packageManager": "pnpm@10.28.0",
   "dependencies": {
-    "@biomejs/biome": "^2.5.8",
+    "@biomejs/biome": "^2.5.10",
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.10",
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
     "ink-testing-library": "^4.0.0",
     "tsdown": "^0.22.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 10 language targets (TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP, C#, C/C++). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
     "ink-testing-library": "^4.0.0",
     "tsdown": "^0.22.14",
     "vite": "^8.2.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
   .:
     dependencies:
       '@biomejs/biome':
-        specifier: ^2.5.8
-        version: 2.5.8
+        specifier: ^2.5.10
+        version: 2.5.10
       '@clack/prompts':
         specifier: ^1.7.0
         version: 1.7.0
@@ -111,55 +111,59 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.8':
-    resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
+  '@biomejs/biome@2.5.10':
+    resolution: {integrity: sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.8':
-    resolution: {integrity: sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==}
+  '@biomejs/cli-darwin-arm64@2.5.10':
+    resolution: {integrity: sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.8':
-    resolution: {integrity: sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==}
+  '@biomejs/cli-darwin-x64@2.5.10':
+    resolution: {integrity: sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.8':
-    resolution: {integrity: sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.10':
+    resolution: {integrity: sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.8':
-    resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
+  '@biomejs/cli-linux-arm64@2.5.10':
+    resolution: {integrity: sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.8':
-    resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
+  '@biomejs/cli-linux-x64-musl@2.5.10':
+    resolution: {integrity: sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.8':
-    resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
+  '@biomejs/cli-linux-x64@2.5.10':
+    resolution: {integrity: sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.8':
-    resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
+  '@biomejs/cli-win32-arm64@2.5.10':
+    resolution: {integrity: sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.8':
-    resolution: {integrity: sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==}
+  '@biomejs/cli-win32-x64@2.5.10':
+    resolution: {integrity: sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -420,48 +424,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.143.0':
     resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
     resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
     resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
     resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
     resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.143.0':
     resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.143.0':
     resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.143.0':
     resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
@@ -538,41 +550,49 @@ packages:
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
@@ -641,48 +661,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.77.0':
     resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.77.0':
     resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.77.0':
     resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.77.0':
     resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.77.0':
     resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.77.0':
     resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.77.0':
     resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
@@ -812,96 +840,112 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.0':
     resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.5':
     resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
     resolution: {integrity: sha512-elPpdevtCdUOqziemR86C4CSCr/5sUxalzDrf/CJdMT+kZt2C556as++qHikNOz0vuFf52h+GJNXZM08eWgGPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.5':
     resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.0':
     resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.5':
     resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
     resolution: {integrity: sha512-IBwXsf56o3xhzAyaZxdM1CX8UFiBEUFCjiVUgny67Q8vPIqkjzJj0YKhd3TbBHanuxThgBa59f6Pgutg2OGk5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.5':
     resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
     resolution: {integrity: sha512-vOk7G8V9Zm+8a6PL6JTpCea61q491oYlGtO6CvnsbhNLlKdf0bbCPytFzGQhYmCKZDKkEbmnkcIprTEGCURnwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.5':
     resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
     resolution: {integrity: sha512-ASjEDI4MRv7XCQb2JVaBzfEYO98JKCGrAgoW6M03fJzH/ilCnC43Mb3ptB9q/lzsaahoJyIBoAGKAYEjUvpyvQ==}
@@ -1048,31 +1092,37 @@ packages:
     resolution: {integrity: sha512-Ur3Awo45Sc5/Fglr8WN5XIf4IwAsq8wLd917Du8ow6mStxsBTHqFiH+tT7d5jV0FqcJnwy8EHVczmgde0zTo1A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-FIy7Ttx8oeUCd/8Y6IjnOsu+lRc6En+V/H67BlVphOeCySZAo5LU8VWrb4tv0DvjaSOzdm3DmdmRzmzN7NCqWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-s+25wl1TLvf+7LzasPEi1RR1sDfVAU0i1QH601mn3vj+HudFYBYNZtUBKFaZvl645QR6vcaDaGHnOaMZhBR3ig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-pRha3Cjm4AnA5wEuhpg+8XXoGfwz5X61/9a/VNxeau47+kH6xjJspkEloIy/HbHgUnvVRqVHoEHczdGZT2J9NA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-GySXmiw5Dw99Ba3GMV2ExQVckihuangnrIpSJagPx8RFUNtwfmzpr2ibf8k31eEAE4YUofV7mEfJN5tN6+POnQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-8YFfcPZz44v8YyekWVKkNz/cD4t6DW62/dr03OVtMfwUtHfmo/8wpby0JKMleAOXbgWItSGw81LtwqM4I9oS0A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-YhENbgkuzjsil+zDNV35oU3PQMDg2RXh8BPt915WCNAbIIHcqgYupHJF3564206+DbPkZtcDvcoa34Wb5B8tbQ==}
@@ -1103,31 +1153,37 @@ packages:
     resolution: {integrity: sha512-+cuJWUK13lwce721XGRjz7izSr2Q1U0RlHkDzdkohWpRWlttTqRdxNnaW13nDc47GBDrNsXMHx+KLcebeOeeGg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-rOVPRqt9cm1YP/wPV+yyZh0FYr6UR/wm/BXslvLuge0LDewVvDrm/AxcDrwWuPAu61Nzdg2rMVfcNnrplCbC1w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-pAoIozKr6E+ptpaQz4CZv1O7cay2f4m7kbd+DSQug5MKdUBTZZ18GdWSPvq0fwQYraH9hZlyLqrMaeP5W/ncrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-JCAg50ahXuYlrsIi1jmymX9X/9B0JYBRroAHnYttN44tAvCo1PFqukHrw1up6HvEOoLA0OjlM0Zwh60u3Gc/Zg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-tEeVQ14etp7lpUqXzq+X5AlQzFH+m3TVDiCKIq17zxnxJ117DOVvoveWSkSMt/lj68z48SvZUMHe7xLvqtO1lg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-+UGRYnF37nnbZNMsMjSGDXKUTIxYUmbbk3Lzib88sLK7kg2y80vjchYYoYsDUK9kAgqPWyA9hKGURHy/Kk9Few==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-l+7Va9/sX1ccRjzjJj6MR0arKsvHB5b419+pKbwzn+/18A/xfccWqmxXrn0C0NyVLlbEb3AV9Is+AbF72O85yA==}
@@ -1628,24 +1684,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2260,39 +2320,39 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@biomejs/biome@2.5.8':
+  '@biomejs/biome@2.5.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.8
-      '@biomejs/cli-darwin-x64': 2.5.8
-      '@biomejs/cli-linux-arm64': 2.5.8
-      '@biomejs/cli-linux-arm64-musl': 2.5.8
-      '@biomejs/cli-linux-x64': 2.5.8
-      '@biomejs/cli-linux-x64-musl': 2.5.8
-      '@biomejs/cli-win32-arm64': 2.5.8
-      '@biomejs/cli-win32-x64': 2.5.8
+      '@biomejs/cli-darwin-arm64': 2.5.10
+      '@biomejs/cli-darwin-x64': 2.5.10
+      '@biomejs/cli-linux-arm64': 2.5.10
+      '@biomejs/cli-linux-arm64-musl': 2.5.10
+      '@biomejs/cli-linux-x64': 2.5.10
+      '@biomejs/cli-linux-x64-musl': 2.5.10
+      '@biomejs/cli-win32-arm64': 2.5.10
+      '@biomejs/cli-win32-x64': 2.5.10
 
-  '@biomejs/cli-darwin-arm64@2.5.8':
+  '@biomejs/cli-darwin-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.8':
+  '@biomejs/cli-darwin-x64@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.8':
+  '@biomejs/cli-linux-arm64-musl@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.8':
+  '@biomejs/cli-linux-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.8':
+  '@biomejs/cli-linux-x64-musl@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.8':
+  '@biomejs/cli-linux-x64@2.5.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.8':
+  '@biomejs/cli-win32-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.8':
+  '@biomejs/cli-win32-x64@2.5.10':
     optional: true
 
   '@clack/core@1.4.3':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -1032,8 +1032,8 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/micromatch@4.0.10':
     resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
@@ -1044,11 +1044,11 @@ packages:
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=7.3.5'
@@ -1058,20 +1058,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.10':
-    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.10':
-    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.10':
-    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@yuku-codegen/binding-darwin-arm64@0.8.0':
     resolution: {integrity: sha512-7cSJH6PaKLRBdCfiB4pM6EukvgOk5xV4tyuLOIOEqrHsbnV7brtyff7CjhZbeGozdIHoOnKOi5R7rrmCWN3QSw==}
@@ -1398,8 +1398,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1435,8 +1435,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   expo-doctor@1.20.3:
@@ -1782,9 +1782,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -1845,12 +1842,12 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -2012,8 +2009,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@8.2.2:
     resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
@@ -2042,24 +2039,20 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -2203,20 +2196,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=7.3.5'
@@ -2854,7 +2847,7 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/estree@1.0.8': {}
+  '@types/estree@1.0.9': {}
 
   '@types/micromatch@4.0.10':
     dependencies:
@@ -2868,46 +2861,46 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/expect@4.1.10':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.10':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/runner@4.1.10':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.10
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.10':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.10': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.10':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@yuku-codegen/binding-darwin-arm64@0.8.0':
     optional: true
@@ -3129,7 +3122,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3173,7 +3166,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   etag@1.8.1: {}
 
@@ -3183,7 +3176,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   expo-doctor@1.20.3: {}
 
@@ -3249,6 +3242,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   figures@6.1.0:
     dependencies:
@@ -3515,8 +3512,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.1: {}
-
   obug@2.1.4: {}
 
   on-finished@2.4.1:
@@ -3613,9 +3608,9 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
+
+  picomatch@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -3839,7 +3834,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.2.0: {}
 
   string-width@8.2.2:
     dependencies:
@@ -3866,21 +3861,16 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3970,26 +3960,26 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.7
+      std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
       vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^14.0.3
         version: 14.0.3
       expo-doctor:
-        specifier: ^1.20.1
-        version: 1.20.1
+        specifier: ^1.20.3
+        version: 1.20.3
       ink:
         specifier: ^7.1.1
         version: 7.1.1(@types/react@19.2.18)(react@19.2.8)
@@ -133,24 +133,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.8':
     resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.8':
     resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.8':
     resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.8':
     resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
@@ -420,48 +424,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.143.0':
     resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
     resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
     resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
     resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
     resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.143.0':
     resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.143.0':
     resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.143.0':
     resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
@@ -538,41 +550,49 @@ packages:
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
@@ -641,48 +661,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.77.0':
     resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.77.0':
     resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.77.0':
     resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.77.0':
     resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.77.0':
     resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.77.0':
     resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.77.0':
     resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
@@ -812,96 +840,112 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.0':
     resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.5':
     resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
     resolution: {integrity: sha512-elPpdevtCdUOqziemR86C4CSCr/5sUxalzDrf/CJdMT+kZt2C556as++qHikNOz0vuFf52h+GJNXZM08eWgGPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.5':
     resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.0':
     resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.5':
     resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
     resolution: {integrity: sha512-IBwXsf56o3xhzAyaZxdM1CX8UFiBEUFCjiVUgny67Q8vPIqkjzJj0YKhd3TbBHanuxThgBa59f6Pgutg2OGk5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.5':
     resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
     resolution: {integrity: sha512-vOk7G8V9Zm+8a6PL6JTpCea61q491oYlGtO6CvnsbhNLlKdf0bbCPytFzGQhYmCKZDKkEbmnkcIprTEGCURnwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.5':
     resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
     resolution: {integrity: sha512-ASjEDI4MRv7XCQb2JVaBzfEYO98JKCGrAgoW6M03fJzH/ilCnC43Mb3ptB9q/lzsaahoJyIBoAGKAYEjUvpyvQ==}
@@ -1048,31 +1092,37 @@ packages:
     resolution: {integrity: sha512-Ur3Awo45Sc5/Fglr8WN5XIf4IwAsq8wLd917Du8ow6mStxsBTHqFiH+tT7d5jV0FqcJnwy8EHVczmgde0zTo1A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-FIy7Ttx8oeUCd/8Y6IjnOsu+lRc6En+V/H67BlVphOeCySZAo5LU8VWrb4tv0DvjaSOzdm3DmdmRzmzN7NCqWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-s+25wl1TLvf+7LzasPEi1RR1sDfVAU0i1QH601mn3vj+HudFYBYNZtUBKFaZvl645QR6vcaDaGHnOaMZhBR3ig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-pRha3Cjm4AnA5wEuhpg+8XXoGfwz5X61/9a/VNxeau47+kH6xjJspkEloIy/HbHgUnvVRqVHoEHczdGZT2J9NA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-GySXmiw5Dw99Ba3GMV2ExQVckihuangnrIpSJagPx8RFUNtwfmzpr2ibf8k31eEAE4YUofV7mEfJN5tN6+POnQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-8YFfcPZz44v8YyekWVKkNz/cD4t6DW62/dr03OVtMfwUtHfmo/8wpby0JKMleAOXbgWItSGw81LtwqM4I9oS0A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-codegen/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-YhENbgkuzjsil+zDNV35oU3PQMDg2RXh8BPt915WCNAbIIHcqgYupHJF3564206+DbPkZtcDvcoa34Wb5B8tbQ==}
@@ -1103,31 +1153,37 @@ packages:
     resolution: {integrity: sha512-+cuJWUK13lwce721XGRjz7izSr2Q1U0RlHkDzdkohWpRWlttTqRdxNnaW13nDc47GBDrNsXMHx+KLcebeOeeGg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-rOVPRqt9cm1YP/wPV+yyZh0FYr6UR/wm/BXslvLuge0LDewVvDrm/AxcDrwWuPAu61Nzdg2rMVfcNnrplCbC1w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-pAoIozKr6E+ptpaQz4CZv1O7cay2f4m7kbd+DSQug5MKdUBTZZ18GdWSPvq0fwQYraH9hZlyLqrMaeP5W/ncrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-JCAg50ahXuYlrsIi1jmymX9X/9B0JYBRroAHnYttN44tAvCo1PFqukHrw1up6HvEOoLA0OjlM0Zwh60u3Gc/Zg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-tEeVQ14etp7lpUqXzq+X5AlQzFH+m3TVDiCKIq17zxnxJ117DOVvoveWSkSMt/lj68z48SvZUMHe7xLvqtO1lg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-+UGRYnF37nnbZNMsMjSGDXKUTIxYUmbbk3Lzib88sLK7kg2y80vjchYYoYsDUK9kAgqPWyA9hKGURHy/Kk9Few==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@yuku-parser/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-l+7Va9/sX1ccRjzjJj6MR0arKsvHB5b419+pKbwzn+/18A/xfccWqmxXrn0C0NyVLlbEb3AV9Is+AbF72O85yA==}
@@ -1383,8 +1439,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  expo-doctor@1.20.1:
-    resolution: {integrity: sha512-u0QYTm3hTZbuMuNdnvscA1X6Xm31ilQ6uxrf8FfzO0ddpOEBrgVEYp8jXgFOBwrRf6DqJoD2j3eKUTWTqvKVzg==}
+  expo-doctor@1.20.3:
+    resolution: {integrity: sha512-lUEJCHbmni/R7mu/aNfpy6UZsD01BbvPRpaHfdbvUo65TtWzUZbZjTiDnfX9/eJWMvNsK5boD5Z17uONKv0dJw==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     hasBin: true
 
@@ -1628,24 +1684,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -3125,7 +3185,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expo-doctor@1.20.1: {}
+  expo-doctor@1.20.3: {}
 
   express-rate-limit@8.6.2(express@5.2.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^4.0.10
         version: 4.0.10
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -100,10 +100,10 @@ importers:
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@6.0.3)(unrun@0.2.29(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))
       vite:
         specifier: ^8.2.2
-        version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -1038,8 +1038,8 @@ packages:
   '@types/micromatch@4.0.10':
     resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
-  '@types/node@26.2.0':
-    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
@@ -2853,7 +2853,7 @@ snapshots:
     dependencies:
       '@types/braces': 3.0.5
 
-  '@types/node@26.2.0':
+  '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -2870,13 +2870,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -3946,7 +3946,7 @@ snapshots:
 
   verkit@0.3.0: {}
 
-  vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -3954,16 +3954,16 @@ snapshots:
       rolldown: 1.2.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.4.0
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -3980,10 +3980,10 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.4.0
     transitivePeerDependencies:
       - msw
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { registerAgentCommand } from "./cli/agent-command.js";
 import { registerHookAliases, registerHookCommand } from "./cli/hook-command.js";
 import { registerExtraCommands } from "./cli-extra-commands.js";
@@ -129,6 +129,9 @@ const fixProgram = program
 		"only apply reversible fixes (imports, comment removal, safe formatters); skip anything that deletes code, rewrites behaviour, or runs unsafe formatter configs",
 	)
 	.option("--dry-run", "print planned fix steps without writing files")
+	.addOption(new Option("--changes", "only fix changed files (git diff)").conflicts("staged"))
+	.addOption(new Option("--staged", "only fix staged files").conflicts("changes"))
+	.option("--base <ref>", "diff base for --changes, e.g. origin/main (default HEAD)")
 	.option("-p, --prompt", "print a prompt for your coding agent to fix remaining issues");
 
 for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
@@ -140,6 +143,9 @@ fixProgram.action(async (directory = ".", _flags, command) => {
 		force: Boolean(flags.force),
 		safe: Boolean(flags.safe),
 		dryRun: Boolean(flags.dryRun),
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: typeof flags.base === "string" ? flags.base : undefined,
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,7 @@ const fixProgram = program
 		"--safe",
 		"only apply reversible fixes (imports, comment removal, safe formatters); skip anything that deletes code, rewrites behaviour, or runs unsafe formatter configs",
 	)
+	.option("--dry-run", "print planned fix steps without writing files")
 	.option("-p, --prompt", "print a prompt for your coding agent to fix remaining issues");
 
 for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
@@ -138,6 +139,7 @@ fixProgram.action(async (directory = ".", _flags, command) => {
 		verbose: Boolean(flags.verbose),
 		force: Boolean(flags.force),
 		safe: Boolean(flags.safe),
+		dryRun: Boolean(flags.dryRun),
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});

--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -27,7 +27,9 @@ export const createEngineContext = (
 	config: { quality: config.quality, security: config.security, lint: config.lint },
 	...(options.scope
 		? {
-				files: [...new Set([...options.scope.files, ...options.scope.testFiles])],
+				// Kept apart the way scan does it: merging them made scoped fixers rewrite test
+				// files that an unscoped fix never touches.
+				files: options.scope.files,
 				testFiles: options.scope.testFiles,
 				projectFiles: options.scope.projectFiles,
 				dependencyAuditFiles: options.scope.dependencyAuditFiles,

--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -1,5 +1,6 @@
 import type { AislopConfig } from "../config/index.js";
 import type { EngineContext } from "../engines/types.js";
+import type { Language } from "../utils/discover.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import type { ProjectInfo } from "./fix-pipeline.js";
 import type { ScanFileScope } from "./scan-file-scope.js";
@@ -8,7 +9,11 @@ export const createEngineContext = (
 	rootDirectory: string,
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: { safe?: boolean; scope?: ScanFileScope } = {},
+	options: {
+		safe?: boolean;
+		scope?: ScanFileScope;
+		dependencyAuditLanguages?: Language[];
+	} = {},
 ): EngineContext => ({
 	rootDirectory,
 	languages: projectInfo.languages,
@@ -27,6 +32,9 @@ export const createEngineContext = (
 				projectFiles: options.scope.projectFiles,
 				dependencyAuditFiles: options.scope.dependencyAuditFiles,
 				dependencyAuditScope: options.scope.dependencyAuditScope,
+				// Scoped languages come from the selected files, so a manifest-only scope has
+				// none. Dependency work is about the project, not the selection.
+				dependencyAuditLanguages: options.dependencyAuditLanguages,
 			}
 		: {}),
 });

--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -2,12 +2,13 @@ import type { AislopConfig } from "../config/index.js";
 import type { EngineContext } from "../engines/types.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import type { ProjectInfo } from "./fix-pipeline.js";
+import type { ScanFileScope } from "./scan-file-scope.js";
 
 export const createEngineContext = (
 	rootDirectory: string,
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: { safe?: boolean } = {},
+	options: { safe?: boolean; scope?: ScanFileScope } = {},
 ): EngineContext => ({
 	rootDirectory,
 	languages: projectInfo.languages,
@@ -19,4 +20,13 @@ export const createEngineContext = (
 		? { ...projectInfo.installedTools, rubocop: false, "php-cs-fixer": false }
 		: projectInfo.installedTools,
 	config: { quality: config.quality, security: config.security, lint: config.lint },
+	...(options.scope
+		? {
+				files: [...new Set([...options.scope.files, ...options.scope.testFiles])],
+				testFiles: options.scope.testFiles,
+				projectFiles: options.scope.projectFiles,
+				dependencyAuditFiles: options.scope.dependencyAuditFiles,
+				dependencyAuditScope: options.scope.dependencyAuditScope,
+			}
+		: {}),
 });

--- a/src/commands/fix-formatting-pipeline.ts
+++ b/src/commands/fix-formatting-pipeline.ts
@@ -11,6 +11,7 @@ import { fixRuffFormat, runRuffFormat } from "../engines/format/ruff-format.js";
 import { log } from "../ui/logger.js";
 import type { PipelineDeps } from "./fix-pipeline.js";
 import { hasJsOrTs } from "./fix-pipeline-language.js";
+import { CANNOT_SCOPE_REASON, isScopedFix } from "./fix-scope.js";
 
 const skipUnsafeSafeFormatter = (deps: PipelineDeps, language: "ruby" | "php"): boolean => {
 	if (!deps.safe) return false;
@@ -51,7 +52,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Formatting (python)",
 			() => runRuffFormat(deps.context),
-			() => fixRuffFormat(deps.resolvedDir),
+			() => fixRuffFormat(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("python")) {
 		log.warn("Python detected but ruff is not installed; skipping Python formatting fixes.");
@@ -61,18 +62,22 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Formatting (go)",
 			() => runGofmt(deps.context),
-			() => fixGofmt(deps.resolvedDir),
+			() => fixGofmt(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("go")) {
 		log.warn("Go detected but gofmt is not installed; skipping Go formatting fixes.");
 	}
 
 	if (deps.projectInfo.languages.includes("rust") && deps.projectInfo.installedTools.rustfmt) {
-		await deps.runStep(
-			"Formatting (rust)",
-			() => runGenericFormatter(deps.context, "rust"),
-			() => fixGenericFormatter(deps.resolvedDir, "rust"),
-		);
+		if (isScopedFix(deps.context)) {
+			deps.skipStep?.("Formatting (rust)", CANNOT_SCOPE_REASON);
+		} else {
+			await deps.runStep(
+				"Formatting (rust)",
+				() => runGenericFormatter(deps.context, "rust"),
+				() => fixGenericFormatter(deps.context, "rust"),
+			);
+		}
 	} else if (deps.projectInfo.languages.includes("rust")) {
 		log.warn("Rust detected but rustfmt is not installed; skipping Rust formatting fixes.");
 	}
@@ -82,7 +87,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 			await deps.runStep(
 				"Formatting (ruby)",
 				() => runGenericFormatter(deps.context, "ruby"),
-				() => fixGenericFormatter(deps.resolvedDir, "ruby"),
+				() => fixGenericFormatter(deps.context, "ruby"),
 			);
 		}
 	} else if (deps.projectInfo.languages.includes("ruby")) {
@@ -97,7 +102,7 @@ export const runFormattingStep = async (deps: PipelineDeps): Promise<void> => {
 			await deps.runStep(
 				"Formatting (php)",
 				() => runGenericFormatter(deps.context, "php"),
-				() => fixGenericFormatter(deps.resolvedDir, "php"),
+				() => fixGenericFormatter(deps.context, "php"),
 			);
 		}
 	} else if (deps.projectInfo.languages.includes("php")) {
@@ -113,6 +118,8 @@ const runNativeFormattingSteps = async (deps: PipelineDeps): Promise<void> => {
 			log.warn(
 				"Skipping C# formatting: set lint.csharp.projectEvaluation: true only for repositories you trust.",
 			);
+		} else if (isScopedFix(deps.context)) {
+			deps.skipStep?.("Formatting (csharp)", CANNOT_SCOPE_REASON);
 		} else if (!skipUnscopableCsharpFormatter(deps)) {
 			await deps.runStep(
 				"Formatting (csharp)",

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -33,7 +33,7 @@ import { hasJsOrTs } from "./fix-pipeline-language.js";
 import {
 	isPathInFixScope,
 	MISSING_MANIFEST_REASON,
-	scopeIncludesDependencyManifest,
+	scopeIncludesManifestWrites,
 } from "./fix-scope.js";
 import type { FixStepResult } from "./fix-steps.js";
 
@@ -151,10 +151,17 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 	}
 };
 
+// Dependency work follows the project's languages, not the selection's: a scope holding
+// only package.json detects no source language but still needs the JS/TS fixers.
+const dependencyLanguages = (deps: PipelineDeps): ProjectInfo => ({
+	...deps.projectInfo,
+	languages: deps.context.dependencyAuditLanguages ?? deps.projectInfo.languages,
+});
+
 export const runDependencyStep = async (deps: PipelineDeps): Promise<void> => {
 	if (!deps.config.engines["code-quality"]) return;
-	if (!hasJsOrTs(deps.projectInfo)) return;
-	if (!scopeIncludesDependencyManifest(deps.context)) {
+	if (!hasJsOrTs(dependencyLanguages(deps))) return;
+	if (!scopeIncludesManifestWrites(deps.context)) {
 		deps.skipStep?.("Unused dependencies", MISSING_MANIFEST_REASON);
 		return;
 	}
@@ -186,7 +193,7 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	const railUpdate = (label: string) => deps.rail.setActiveLabel(label);
 
 	if (deps.config.engines.security) {
-		if (!scopeIncludesDependencyManifest(deps.context)) {
+		if (!scopeIncludesManifestWrites(deps.context)) {
 			deps.skipStep?.("Dependency audit fixes", MISSING_MANIFEST_REASON);
 		} else {
 			await deps.runStep(
@@ -198,7 +205,7 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	}
 
 	if (deps.projectInfo.frameworks.includes("expo") && deps.config.lint.expoDoctor) {
-		if (!scopeIncludesDependencyManifest(deps.context)) {
+		if (!scopeIncludesManifestWrites(deps.context)) {
 			deps.skipStep?.("Expo dependency alignment", MISSING_MANIFEST_REASON);
 		} else {
 			await deps.runStep(

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -30,6 +30,11 @@ import type { discoverProject } from "../utils/discover.js";
 import { fixExpoDependencies } from "./fix-expo.js";
 import { fixDependencyAudit } from "./fix-force.js";
 import { hasJsOrTs } from "./fix-pipeline-language.js";
+import {
+	isPathInFixScope,
+	MISSING_MANIFEST_REASON,
+	scopeIncludesDependencyManifest,
+} from "./fix-scope.js";
 import type { FixStepResult } from "./fix-steps.js";
 
 export { runFormattingStep } from "./fix-formatting-pipeline.js";
@@ -55,6 +60,7 @@ export interface PipelineDeps {
 	// Restrict to reversible fixes only (imports, comment removal, safe formatter runs).
 	safe: boolean;
 	runStep: RunStepFn;
+	skipStep?: (name: string, reason: string) => void;
 }
 
 export const runAiSlopSteps = async (deps: PipelineDeps): Promise<void> => {
@@ -128,7 +134,7 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Lint fixes (python)",
 			() => runRuffLint(deps.context),
-			() => (deps.force ? fixRuffLintForce(deps.resolvedDir) : fixRuffLint(deps.resolvedDir)),
+			() => (deps.force ? fixRuffLintForce(deps.context) : fixRuffLint(deps.context)),
 		);
 	} else if (deps.projectInfo.languages.includes("python")) {
 		log.warn("Python detected but ruff is not installed; skipping Python lint fixes.");
@@ -138,7 +144,7 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 		await deps.runStep(
 			"Lint fixes (ruby)",
 			() => runGenericLinter(deps.context, "ruby"),
-			() => fixRubyLint(deps.resolvedDir),
+			() => fixRubyLint(deps.context),
 		);
 	} else if (deps.projectInfo.languages.includes("ruby")) {
 		log.warn("Ruby detected but rubocop is not installed; skipping Ruby lint fixes.");
@@ -148,6 +154,10 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 export const runDependencyStep = async (deps: PipelineDeps): Promise<void> => {
 	if (!deps.config.engines["code-quality"]) return;
 	if (!hasJsOrTs(deps.projectInfo)) return;
+	if (!scopeIncludesDependencyManifest(deps.context)) {
+		deps.skipStep?.("Unused dependencies", MISSING_MANIFEST_REASON);
+		return;
+	}
 
 	await deps.runStep(
 		"Unused dependencies",
@@ -162,26 +172,40 @@ export const runForceSteps = async (deps: PipelineDeps): Promise<void> => {
 	if (deps.config.engines["code-quality"] && hasJsOrTs(deps.projectInfo)) {
 		await deps.runStep(
 			"Remove unused files",
-			() => runKnipUnusedFiles(deps.resolvedDir),
-			() => fixUnusedFiles(deps.resolvedDir),
+			async () => {
+				const diagnostics = await runKnipUnusedFiles(deps.resolvedDir);
+				return diagnostics.filter((diagnostic) =>
+					isPathInFixScope(deps.context, diagnostic.filePath),
+				);
+			},
+			() =>
+				fixUnusedFiles(deps.resolvedDir, (filePath) => isPathInFixScope(deps.context, filePath)),
 		);
 	}
 
 	const railUpdate = (label: string) => deps.rail.setActiveLabel(label);
 
 	if (deps.config.engines.security) {
-		await deps.runStep(
-			"Dependency audit fixes",
-			() => runDependencyAudit(deps.context),
-			() => fixDependencyAudit(deps.context, railUpdate),
-		);
+		if (!scopeIncludesDependencyManifest(deps.context)) {
+			deps.skipStep?.("Dependency audit fixes", MISSING_MANIFEST_REASON);
+		} else {
+			await deps.runStep(
+				"Dependency audit fixes",
+				() => runDependencyAudit(deps.context),
+				() => fixDependencyAudit(deps.context, railUpdate),
+			);
+		}
 	}
 
 	if (deps.projectInfo.frameworks.includes("expo") && deps.config.lint.expoDoctor) {
-		await deps.runStep(
-			"Expo dependency alignment",
-			() => runExpoDoctor(deps.context),
-			() => fixExpoDependencies(deps.context, railUpdate),
-		);
+		if (!scopeIncludesDependencyManifest(deps.context)) {
+			deps.skipStep?.("Expo dependency alignment", MISSING_MANIFEST_REASON);
+		} else {
+			await deps.runStep(
+				"Expo dependency alignment",
+				() => runExpoDoctor(deps.context),
+				() => fixExpoDependencies(deps.context, railUpdate),
+			);
+		}
 	}
 };

--- a/src/commands/fix-plan.ts
+++ b/src/commands/fix-plan.ts
@@ -118,6 +118,17 @@ const planFormatters = (
 		projectInfo.languages.includes("php") && Boolean(projectInfo.installedTools["php-cs-fixer"]),
 		safe ? SKIPPED_BY_SAFE : undefined,
 	);
+	add(
+		"Formatting (csharp)",
+		projectInfo.languages.includes("csharp") &&
+			Boolean(projectInfo.installedTools.dotnet) &&
+			config.lint?.csharp?.projectEvaluation === true,
+	);
+	add(
+		"Formatting (cpp)",
+		projectInfo.languages.includes("cpp") &&
+			Boolean(projectInfo.installedTools["clang-format"]),
+	);
 	return steps;
 };
 

--- a/src/commands/fix-plan.ts
+++ b/src/commands/fix-plan.ts
@@ -126,8 +126,7 @@ const planFormatters = (
 	);
 	add(
 		"Formatting (cpp)",
-		projectInfo.languages.includes("cpp") &&
-			Boolean(projectInfo.installedTools["clang-format"]),
+		projectInfo.languages.includes("cpp") && Boolean(projectInfo.installedTools["clang-format"]),
 	);
 	return steps;
 };

--- a/src/commands/fix-plan.ts
+++ b/src/commands/fix-plan.ts
@@ -1,72 +1,182 @@
 import type { AislopConfig } from "../config/index.js";
 import type { ProjectInfo } from "../utils/discover.js";
 
-interface FixStepPlanOptions {
-	force?: boolean;
+export interface FixPlanStep {
+	name: string;
+	status: "planned" | "skipped";
+	reason?: string;
 }
+
+export interface FixPlanOptions {
+	force?: boolean;
+	safe?: boolean;
+}
+
+const SKIPPED_BY_SAFE = "skipped by --safe";
+const DISABLED_IN_CONFIG = "disabled in config";
 
 const hasJsTs = (projectInfo: ProjectInfo): boolean =>
 	projectInfo.languages.includes("typescript") || projectInfo.languages.includes("javascript");
 
+const planned = (name: string): FixPlanStep => ({ name, status: "planned" });
+
+const skipped = (name: string, reason: string): FixPlanStep => ({
+	name,
+	status: "skipped",
+	reason,
+});
+
+const gated = (name: string, enabled: boolean, reason: string): FixPlanStep =>
+	enabled ? planned(name) : skipped(name, reason);
+
+const planAiSlop = (config: AislopConfig, safe: boolean): FixPlanStep[] => {
+	if (!config.engines["ai-slop"]) {
+		const names = safe
+			? ["Unused imports", "Duplicate imports", "Narrative comments"]
+			: ["Unused imports", "Duplicate imports", "Dead code & comments"];
+		return names.map((name) => skipped(name, DISABLED_IN_CONFIG));
+	}
+	if (safe) {
+		return [
+			planned("Unused imports"),
+			planned("Duplicate imports"),
+			planned("Narrative comments"),
+			skipped("Dead code & comments", SKIPPED_BY_SAFE),
+		];
+	}
+	return [planned("Unused imports"), planned("Duplicate imports"), planned("Dead code & comments")];
+};
+
+const planQualityStep = (
+	name: string,
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	safe: boolean,
+): FixPlanStep[] => {
+	if (!hasJsTs(projectInfo)) return [];
+	const qualityOn = config.engines["code-quality"];
+	const reason = safe ? SKIPPED_BY_SAFE : qualityOn ? "" : DISABLED_IN_CONFIG;
+	return [reason ? skipped(name, reason) : planned(name)];
+};
+
+const planLint = (projectInfo: ProjectInfo, config: AislopConfig, safe: boolean): FixPlanStep[] => {
+	const steps: FixPlanStep[] = [];
+	const reason = safe ? SKIPPED_BY_SAFE : config.engines.lint ? "" : DISABLED_IN_CONFIG;
+	if (hasJsTs(projectInfo)) {
+		steps.push(reason ? skipped("Lint fixes (js/ts)", reason) : planned("Lint fixes (js/ts)"));
+	}
+	if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
+		steps.push(reason ? skipped("Lint fixes (python)", reason) : planned("Lint fixes (python)"));
+	}
+	if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
+		steps.push(reason ? skipped("Lint fixes (ruby)", reason) : planned("Lint fixes (ruby)"));
+	}
+	return steps;
+};
+
+const planFormatters = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	safe: boolean,
+): FixPlanStep[] => {
+	const steps: FixPlanStep[] = [];
+	const formatOn = config.engines.format;
+	const engineReason = formatOn ? "" : DISABLED_IN_CONFIG;
+	const add = (name: string, eligible: boolean, extraReason?: string) => {
+		if (!eligible) return;
+		if (engineReason) {
+			steps.push(skipped(name, engineReason));
+			return;
+		}
+		if (extraReason) {
+			steps.push(skipped(name, extraReason));
+			return;
+		}
+		steps.push(planned(name));
+	};
+
+	add("Formatting (js/ts)", hasJsTs(projectInfo));
+	add(
+		"Formatting (python)",
+		projectInfo.languages.includes("python") && Boolean(projectInfo.installedTools.ruff),
+	);
+	add(
+		"Formatting (go)",
+		projectInfo.languages.includes("go") && Boolean(projectInfo.installedTools.gofmt),
+	);
+	add(
+		"Formatting (rust)",
+		projectInfo.languages.includes("rust") && Boolean(projectInfo.installedTools.rustfmt),
+	);
+	add(
+		"Formatting (ruby)",
+		projectInfo.languages.includes("ruby") && Boolean(projectInfo.installedTools.rubocop),
+		safe ? SKIPPED_BY_SAFE : undefined,
+	);
+	add(
+		"Formatting (php)",
+		projectInfo.languages.includes("php") && Boolean(projectInfo.installedTools["php-cs-fixer"]),
+		safe ? SKIPPED_BY_SAFE : undefined,
+	);
+	return steps;
+};
+
+const planForce = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	options: { safe: boolean; forceRequested: boolean },
+): FixPlanStep[] => {
+	if (!options.forceRequested) return [];
+	const reason = options.safe ? SKIPPED_BY_SAFE : "";
+	const steps: FixPlanStep[] = [];
+	if (hasJsTs(projectInfo)) {
+		steps.push(
+			reason
+				? skipped("Remove unused files", reason)
+				: gated("Remove unused files", config.engines["code-quality"], DISABLED_IN_CONFIG),
+		);
+	}
+	steps.push(
+		reason
+			? skipped("Dependency audit fixes", reason)
+			: gated("Dependency audit fixes", config.engines.security, DISABLED_IN_CONFIG),
+	);
+	if (projectInfo.frameworks.includes("expo")) {
+		const expoOn = config.lint.expoDoctor;
+		steps.push(
+			reason
+				? skipped("Expo dependency alignment", reason)
+				: gated("Expo dependency alignment", expoOn, "Expo Doctor is not enabled"),
+		);
+	}
+	return steps;
+};
+
+export const buildFixPlan = (
+	projectInfo: ProjectInfo,
+	config: AislopConfig,
+	options: FixPlanOptions = {},
+): FixPlanStep[] => {
+	const safe = Boolean(options.safe);
+	const forceRequested = Boolean(options.force);
+	return [
+		...planAiSlop(config, safe),
+		...planQualityStep("Unused declarations", projectInfo, config, safe),
+		...planLint(projectInfo, config, safe),
+		...planQualityStep("Unused dependencies", projectInfo, config, safe),
+		...planFormatters(projectInfo, config, safe),
+		...planForce(projectInfo, config, { safe, forceRequested }),
+	];
+};
+
 export const buildFixStepNames = (
 	projectInfo: ProjectInfo,
 	config: AislopConfig,
-	options: FixStepPlanOptions,
-): string[] => {
-	const stepNames: string[] = [];
+	options: FixPlanOptions = {},
+): string[] =>
+	buildFixPlan(projectInfo, config, options)
+		.filter((step) => step.status === "planned")
+		.map((step) => step.name);
 
-	if (config.engines["ai-slop"]) {
-		stepNames.push("Unused imports", "Dead code & comments");
-	}
-
-	if (config.engines.lint) {
-		if (hasJsTs(projectInfo)) {
-			stepNames.push("Lint fixes (js/ts)");
-		}
-		if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
-			stepNames.push("Lint fixes (python)");
-		}
-		if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
-			stepNames.push("Lint fixes (ruby)");
-		}
-	}
-
-	if (config.engines["code-quality"] && hasJsTs(projectInfo)) {
-		stepNames.push("Unused dependencies");
-	}
-
-	if (config.engines.format) {
-		if (hasJsTs(projectInfo)) {
-			stepNames.push("Formatting (js/ts)");
-		}
-		if (projectInfo.languages.includes("python") && projectInfo.installedTools.ruff) {
-			stepNames.push("Formatting (python)");
-		}
-		if (projectInfo.languages.includes("go") && projectInfo.installedTools.gofmt) {
-			stepNames.push("Formatting (go)");
-		}
-		if (projectInfo.languages.includes("rust") && projectInfo.installedTools.rustfmt) {
-			stepNames.push("Formatting (rust)");
-		}
-		if (projectInfo.languages.includes("ruby") && projectInfo.installedTools.rubocop) {
-			stepNames.push("Formatting (ruby)");
-		}
-		if (projectInfo.languages.includes("php") && projectInfo.installedTools["php-cs-fixer"]) {
-			stepNames.push("Formatting (php)");
-		}
-	}
-
-	if (options.force) {
-		if (config.engines["code-quality"] && hasJsTs(projectInfo)) {
-			stepNames.push("Remove unused files");
-		}
-		if (config.engines.security) {
-			stepNames.push("Dependency audit fixes");
-		}
-		if (projectInfo.frameworks.includes("expo") && config.lint.expoDoctor) {
-			stepNames.push("Expo dependency alignment");
-		}
-	}
-
-	return stepNames;
-};
+export const skippedFixSteps = (plan: FixPlanStep[]): FixPlanStep[] =>
+	plan.filter((step) => step.status === "skipped");

--- a/src/commands/fix-render.ts
+++ b/src/commands/fix-render.ts
@@ -47,3 +47,5 @@ export const buildFixRender = (input: BuildFixRenderInput): string => {
 			: "";
 	return `${header}${rail}${tail}`;
 };
+
+export const NO_CHANGES_APPLIED = "No changes were applied.";

--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -66,8 +66,10 @@ const WRITTEN_LOCKFILES = [
 
 export const scopeIncludesManifestWrites = (context: EngineContext): boolean => {
 	if (!isScopedFix(context)) return true;
+	// Manifests and lockfiles are collected separately: context.files holds only source
+	// extensions, so package.json is never in it and reading it here always says no.
 	const selected = new Set(
-		(context.files ?? []).map((candidate) =>
+		(context.dependencyAuditFiles ?? []).map((candidate) =>
 			projectRelativePosix(context.rootDirectory, candidate),
 		),
 	);

--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -1,6 +1,7 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { EngineContext } from "../engines/types.js";
 import { projectRelativePosix } from "../utils/paths.js";
-import { isDependencyAuditInputFile } from "../utils/source-file-selection.js";
 import { collectScanFileScope, type ScanFileScope } from "./scan-file-scope.js";
 import { resolveScanScopeMode, type ScanOptions } from "./scan-options.js";
 import { scanTargetError } from "./scan-validation.js";
@@ -53,11 +54,26 @@ export const collectFixFileScope = (
 
 export const isScopedFix = (context: EngineContext): boolean => context.files !== undefined;
 
-export const scopeIncludesDependencyManifest = (context: EngineContext): boolean => {
+// Every dependency fixer rewrites package.json, and npm/pnpm/expo also rewrite the
+// lockfile. A scope holding only one of them would let a fix touch the other.
+const WRITTEN_LOCKFILES = [
+	"package-lock.json",
+	"pnpm-lock.yaml",
+	"yarn.lock",
+	"bun.lock",
+	"bun.lockb",
+];
+
+export const scopeIncludesManifestWrites = (context: EngineContext): boolean => {
 	if (!isScopedFix(context)) return true;
-	const files = context.dependencyAuditFiles ?? context.files ?? [];
-	return files.some((filePath) =>
-		isDependencyAuditInputFile(projectRelativePosix(context.rootDirectory, filePath)),
+	const selected = new Set(
+		(context.files ?? []).map((candidate) =>
+			projectRelativePosix(context.rootDirectory, candidate),
+		),
+	);
+	if (!selected.has("package.json")) return false;
+	return WRITTEN_LOCKFILES.every(
+		(name) => !fs.existsSync(path.join(context.rootDirectory, name)) || selected.has(name),
 	);
 };
 

--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -1,0 +1,73 @@
+import type { EngineContext } from "../engines/types.js";
+import { projectRelativePosix } from "../utils/paths.js";
+import { isDependencyAuditInputFile } from "../utils/source-file-selection.js";
+import { collectScanFileScope, type ScanFileScope } from "./scan-file-scope.js";
+import { resolveScanScopeMode, type ScanOptions } from "./scan-options.js";
+import { scanTargetError } from "./scan-validation.js";
+
+export interface FixScopeFlags {
+	changes?: boolean;
+	staged?: boolean;
+	base?: string;
+}
+
+export const CANNOT_SCOPE_REASON = "cannot honour an explicit file list under --changes/--staged";
+
+export const MISSING_MANIFEST_REASON = "no manifest or lockfile in the selected scope";
+
+export const fixScopeError = (resolvedDir: string, flags: FixScopeFlags): string | null => {
+	if (flags.changes && flags.staged) {
+		return "--changes and --staged cannot be used together.";
+	}
+	const options: ScanOptions = {
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: flags.base,
+		verbose: false,
+		json: false,
+	};
+	return scanTargetError(resolvedDir, options);
+};
+
+export const collectFixFileScope = (
+	rootDirectory: string,
+	excludePatterns: string[],
+	includePatterns: string[],
+	flags: FixScopeFlags,
+): ScanFileScope | null => {
+	const mode = resolveScanScopeMode({
+		changes: Boolean(flags.changes),
+		staged: Boolean(flags.staged),
+		base: flags.base,
+		verbose: false,
+		json: false,
+	});
+	if (mode.kind === "full") return null;
+	return collectScanFileScope({
+		excludePatterns,
+		includePatterns,
+		mode,
+		rootDirectory,
+	});
+};
+
+export const isScopedFix = (context: EngineContext): boolean => context.files !== undefined;
+
+export const scopeIncludesDependencyManifest = (context: EngineContext): boolean => {
+	if (!isScopedFix(context)) return true;
+	const files = context.dependencyAuditFiles ?? context.files ?? [];
+	return files.some((filePath) =>
+		isDependencyAuditInputFile(projectRelativePosix(context.rootDirectory, filePath)),
+	);
+};
+
+export const isPathInFixScope = (context: EngineContext, filePath: string): boolean => {
+	if (!isScopedFix(context)) return true;
+	const relative = projectRelativePosix(context.rootDirectory, filePath);
+	const allowed = new Set(
+		(context.files ?? []).map((candidate) =>
+			projectRelativePosix(context.rootDirectory, candidate),
+		),
+	);
+	return allowed.has(relative);
+};

--- a/src/commands/fix-steps.ts
+++ b/src/commands/fix-steps.ts
@@ -17,7 +17,6 @@ const uniqueFileCount = (diagnostics: Diagnostic[]): number =>
 	new Set(diagnostics.map((d) => d.filePath)).size;
 
 export interface RunFixStepOptions {
-	/** Detect only. Never invoke the mutating fixer. */
 	dryRun?: boolean;
 }
 

--- a/src/commands/fix-steps.ts
+++ b/src/commands/fix-steps.ts
@@ -16,13 +16,31 @@ export interface FixStepResult {
 const uniqueFileCount = (diagnostics: Diagnostic[]): number =>
 	new Set(diagnostics.map((d) => d.filePath)).size;
 
+export interface RunFixStepOptions {
+	/** Detect only. Never invoke the mutating fixer. */
+	dryRun?: boolean;
+}
+
 export const runOneFixStep = async (
 	name: string,
 	detect: () => Promise<Diagnostic[]>,
 	applyFix: () => Promise<void>,
+	options: RunFixStepOptions = {},
 ): Promise<FixStepResult> => {
 	const started = performance.now();
 	const before = await detect();
+	if (options.dryRun) {
+		return {
+			name,
+			beforeIssues: before.length,
+			afterIssues: before.length,
+			resolvedIssues: 0,
+			beforeFiles: uniqueFileCount(before),
+			failed: false,
+			elapsedMs: performance.now() - started,
+			afterDiagnostics: before,
+		};
+	}
 	let applyError: unknown = null;
 	if (before.length > 0) {
 		try {
@@ -65,3 +83,15 @@ export const statusFor = (s: FixStepResult): RailStep["status"] => {
 	if (s.afterIssues > 0) return "warn";
 	return "done";
 };
+
+const findingLabel = (count: number): string => (count === 1 ? "finding" : "findings");
+const fileLabel = (count: number): string => (count === 1 ? "file" : "files");
+
+export const describePreviewStep = (result: FixStepResult): string => {
+	if (result.beforeIssues === 0) {
+		return `${result.name} - 0 findings`;
+	}
+	return `${result.name} - ${result.beforeIssues} ${findingLabel(result.beforeIssues)} in ${result.beforeFiles} ${fileLabel(result.beforeFiles)}`;
+};
+
+export const describeSkippedStep = (name: string, reason: string): string => `${name} - ${reason}`;

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -8,7 +8,7 @@ import { calculateScore } from "../scoring/index.js";
 import { withCommandLifecycle } from "../telemetry/index.js";
 import { renderHeader } from "../ui/header.js";
 import { LiveRail } from "../ui/live-rail.js";
-import { log } from "../ui/logger.js";
+import { log, renderHintLine } from "../ui/logger.js";
 import { theme as defaultTheme, style } from "../ui/theme.js";
 import { discoverProject } from "../utils/discover.js";
 import { APP_VERSION } from "../version.js";
@@ -23,7 +23,16 @@ import {
 	runFormattingStep,
 	runLintSteps,
 } from "./fix-pipeline.js";
-import { describeStep, type FixStepResult, runOneFixStep, statusFor } from "./fix-steps.js";
+import { buildFixPlan, skippedFixSteps } from "./fix-plan.js";
+import { NO_CHANGES_APPLIED } from "./fix-render.js";
+import {
+	describePreviewStep,
+	describeSkippedStep,
+	describeStep,
+	type FixStepResult,
+	runOneFixStep,
+	statusFor,
+} from "./fix-steps.js";
 import { buildScanRender } from "./scan.js";
 
 export { buildFixRender } from "./fix-render.js";
@@ -33,6 +42,8 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
+	/** Detect and print the plan without invoking mutating fixers */
+	dryRun?: boolean;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;
 	/** Print the prompt to stdout instead of launching an agent */
@@ -98,9 +109,52 @@ export const fixCommand = async (
 			config: config.telemetry,
 			languages: projectInfo.languages,
 			fileCount: projectInfo.sourceFileCount,
+			properties: options.dryRun ? { dry_run: true } : undefined,
 		},
 		() => runFixBody(resolvedDir, config, options, projectInfo),
 	);
+};
+
+const runFixPipeline = async (deps: PipelineDeps, safe: boolean): Promise<void> => {
+	await runAiSlopSteps(deps);
+	if (!safe) {
+		await runDeclarationStep(deps);
+		await runLintSteps(deps);
+		await runDependencyStep(deps);
+	}
+	await runFormattingStep(deps);
+	await runForceSteps(deps);
+};
+
+const finishDryRun = (input: {
+	rail: LiveRail;
+	steps: FixStepResult[];
+	projectInfo: Awaited<ReturnType<typeof discoverProject>>;
+	config: AislopConfig;
+	options: FixOptions;
+}): { exitCode: number; fixSteps: number; fixResolved: number } => {
+	const plan = buildFixPlan(input.projectInfo, input.config, {
+		force: Boolean(input.options.force),
+		safe: Boolean(input.options.safe),
+	});
+	const ran = new Set(input.steps.map((step) => step.name));
+	for (const step of skippedFixSteps(plan)) {
+		if (ran.has(step.name)) continue;
+		input.rail.complete({
+			status: "skipped",
+			label: describeSkippedStep(step.name, step.reason ?? "skipped"),
+		});
+	}
+	if (input.steps.length === 0 && skippedFixSteps(plan).length === 0) {
+		input.rail.complete({ status: "skipped", label: "No applicable auto-fixers found" });
+	}
+	input.rail.finish({ footer: "Preview · no changes applied" });
+	process.stdout.write(`\n${renderHintLine(NO_CHANGES_APPLIED)}`);
+	return {
+		exitCode: 0,
+		fixSteps: input.steps.length,
+		fixResolved: 0,
+	};
 };
 
 const runFixBody = async (
@@ -113,11 +167,12 @@ const runFixBody = async (
 	const showHeader = options.showHeader !== false;
 	const projectName = projectInfo.projectName ?? "project";
 
+	const dryRun = Boolean(options.dryRun);
 	if (showHeader) {
 		process.stdout.write(
 			renderHeader({
 				version: APP_VERSION,
-				command: "Fix run",
+				command: dryRun ? "Fix plan" : "Fix run",
 				context: [projectName],
 				brand: options.printBrand !== false,
 			}),
@@ -127,7 +182,7 @@ const runFixBody = async (
 	const safe = Boolean(options.safe);
 	const context = createEngineContext(resolvedDir, projectInfo, config, { safe });
 	const steps: FixStepResult[] = [];
-	const rail = new LiveRail();
+	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
 
 	const runStep = async (
 		name: string,
@@ -135,9 +190,12 @@ const runFixBody = async (
 		applyFix: () => Promise<void>,
 	) => {
 		rail.start(name);
-		const result = await runOneFixStep(name, detect, applyFix);
+		const result = await runOneFixStep(name, detect, applyFix, { dryRun });
 		steps.push(result);
-		rail.complete({ status: statusFor(result), label: describeStep(result) });
+		rail.complete({
+			status: dryRun ? "done" : statusFor(result),
+			label: dryRun ? describePreviewStep(result) : describeStep(result),
+		});
 		return result;
 	};
 
@@ -152,17 +210,17 @@ const runFixBody = async (
 		runStep,
 	};
 
-	await runAiSlopSteps(pipelineDeps);
-	// Safe mode skips the steps that delete code or rewrite behaviour/attributes.
-	if (!safe) {
-		await runDeclarationStep(pipelineDeps);
-		await runLintSteps(pipelineDeps);
-		await runDependencyStep(pipelineDeps);
+	await runFixPipeline(pipelineDeps, safe);
+
+	if (dryRun) {
+		return finishDryRun({
+			rail,
+			steps,
+			projectInfo,
+			config,
+			options,
+		});
 	}
-
-	await runFormattingStep(pipelineDeps);
-
-	await runForceSteps(pipelineDeps);
 
 	const totalResolved = steps.reduce((sum, s) => sum + s.resolvedIssues, 0);
 

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -6,11 +6,13 @@ import { runEngines } from "../engines/orchestrator.js";
 import type { Diagnostic, EngineConfig, EngineResult } from "../engines/types.js";
 import { calculateScore } from "../scoring/index.js";
 import { withCommandLifecycle } from "../telemetry/index.js";
+import { renderDisplayRows } from "../ui/display.js";
 import { renderHeader } from "../ui/header.js";
 import { LiveRail } from "../ui/live-rail.js";
 import { log, renderHintLine } from "../ui/logger.js";
 import { theme as defaultTheme, style } from "../ui/theme.js";
-import { discoverProject } from "../utils/discover.js";
+import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
+import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { APP_VERSION } from "../version.js";
 import { launchAgent, printPrompt } from "./fix-code.js";
 import { createEngineContext } from "./fix-context.js";
@@ -25,6 +27,7 @@ import {
 } from "./fix-pipeline.js";
 import { buildFixPlan, skippedFixSteps } from "./fix-plan.js";
 import { NO_CHANGES_APPLIED } from "./fix-render.js";
+import { collectFixFileScope, fixScopeError } from "./fix-scope.js";
 import {
 	describePreviewStep,
 	describeSkippedStep,
@@ -44,6 +47,9 @@ interface FixOptions {
 	safe?: boolean;
 	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
+	changes?: boolean;
+	staged?: boolean;
+	base?: string;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;
 	/** Print the prompt to stdout instead of launching an agent */
@@ -97,6 +103,14 @@ export const fixCommand = async (
 			: `Not a directory: ${resolvedDir}`;
 		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
 			log.error(msg);
+			return { exitCode: 1 };
+		});
+	}
+
+	const scopeError = fixScopeError(resolvedDir, options);
+	if (scopeError) {
+		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
+			log.error(scopeError);
 			return { exitCode: 1 };
 		});
 	}
@@ -180,7 +194,31 @@ const runFixBody = async (
 	}
 
 	const safe = Boolean(options.safe);
-	const context = createEngineContext(resolvedDir, projectInfo, config, { safe });
+	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
+	const scope = collectFixFileScope(resolvedDir, excludePatterns, config.include, options);
+	const scopedProjectInfo = scope
+		? {
+				...projectInfo,
+				languages: detectSourceLanguages([...scope.files, ...scope.testFiles]),
+			}
+		: projectInfo;
+	const context = createEngineContext(resolvedDir, scopedProjectInfo, config, {
+		safe,
+		scope: scope ?? undefined,
+	});
+	if (scope) {
+		process.stdout.write(
+			`${renderDisplayRows(
+				[
+					{
+						label: "Scope",
+						value: `${scope.files.length + scope.testFiles.length} ${scope.scopeLabel}`,
+					},
+				],
+				{ indent: 1 },
+			).join("\n")}\n`,
+		);
+	}
 	const steps: FixStepResult[] = [];
 	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
 
@@ -199,15 +237,20 @@ const runFixBody = async (
 		return result;
 	};
 
+	const skipStep = (name: string, reason: string) => {
+		rail.complete({ status: "skipped", label: describeSkippedStep(name, reason) });
+	};
+
 	const pipelineDeps: PipelineDeps = {
 		rail,
 		context,
 		config,
 		resolvedDir,
-		projectInfo,
+		projectInfo: scopedProjectInfo,
 		force: safe ? false : Boolean(options.force),
 		safe,
 		runStep,
+		skipStep,
 	};
 
 	await runFixPipeline(pipelineDeps, safe);
@@ -216,7 +259,7 @@ const runFixBody = async (
 		return finishDryRun({
 			rail,
 			steps,
-			projectInfo,
+			projectInfo: scopedProjectInfo,
 			config,
 			options,
 		});
@@ -237,11 +280,20 @@ const runFixBody = async (
 	const verificationResults = await runEngines(
 		{
 			rootDirectory: resolvedDir,
-			languages: projectInfo.languages,
+			languages: scopedProjectInfo.languages,
 			frameworks: projectInfo.frameworks,
 			excludePatterns: context.excludePatterns,
 			installedTools: context.installedTools,
 			config: engineConfig,
+			...(scope
+				? {
+						files: context.files,
+						testFiles: context.testFiles,
+						projectFiles: context.projectFiles,
+						dependencyAuditFiles: context.dependencyAuditFiles,
+						dependencyAuditScope: context.dependencyAuditScope,
+					}
+				: {}),
 		},
 		buildPostFixVerificationEngines(config.engines),
 		() => {},
@@ -258,7 +310,7 @@ const runFixBody = async (
 		allDiagnostics,
 		config.scoring.weights,
 		config.scoring.thresholds,
-		projectInfo.sourceFileCount,
+		scope ? scope.files.length + scope.testFiles.length : projectInfo.sourceFileCount,
 		config.scoring.smoothing,
 		config.scoring.maxPerRule,
 	);
@@ -284,12 +336,14 @@ const runFixBody = async (
 				`\n ${style(t, "success", `Resolved ${totalResolved} issue${totalResolved === 1 ? "" : "s"}`)} ${arrow} ${style(t, "success", `${scoreResult.score} / 100 ${scoreResult.label}`)}\n`,
 			);
 		}
-		const language = projectInfo.languages[0] ?? "unknown";
+		const language = scopedProjectInfo.languages[0] ?? "unknown";
 		process.stdout.write(
 			buildScanRender({
 				projectName,
 				language,
-				fileCount: projectInfo.sourceFileCount,
+				fileCount: scope
+					? scope.files.length + scope.testFiles.length
+					: projectInfo.sourceFileCount,
 				results: scanResults,
 				diagnostics: actionableDiagnostics,
 				score: scoreResult,

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -45,7 +45,6 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
-	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
 	changes?: boolean;
 	staged?: boolean;

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -106,6 +106,13 @@ export const fixCommand = async (
 		});
 	}
 
+	if (options.dryRun && (options.agent || options.prompt)) {
+		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
+			log.error("--dry-run cannot be combined with an agent handoff or --prompt.");
+			return { exitCode: 1 };
+		});
+	}
+
 	const scopeError = fixScopeError(resolvedDir, options);
 	if (scopeError) {
 		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
@@ -220,7 +227,8 @@ const runFixBody = async (
 		);
 	}
 	const steps: FixStepResult[] = [];
-	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
+	const isCi = process.env.CI === "true" || process.env.CI === "1";
+	const rail = new LiveRail(isCi ? { tty: false } : {});
 
 	const runStep = async (
 		name: string,
@@ -310,7 +318,7 @@ const runFixBody = async (
 		allDiagnostics,
 		config.scoring.weights,
 		config.scoring.thresholds,
-		scope ? scope.files.length + scope.testFiles.length : projectInfo.sourceFileCount,
+		scope ? scope.scoreFileCount : projectInfo.sourceFileCount,
 		config.scoring.smoothing,
 		config.scoring.maxPerRule,
 	);

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -204,6 +204,7 @@ const runFixBody = async (
 	const context = createEngineContext(resolvedDir, scopedProjectInfo, config, {
 		safe,
 		scope: scope ?? undefined,
+		dependencyAuditLanguages: projectInfo.languages,
 	});
 	if (scope) {
 		process.stdout.write(

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -42,7 +42,6 @@ interface FixOptions {
 	force?: boolean;
 	/** Restrict to reversible fixes only (imports, comment removal, safe formatter runs) */
 	safe?: boolean;
-	/** Detect and print the plan without invoking mutating fixers */
 	dryRun?: boolean;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;

--- a/src/commands/scan-file-scope.ts
+++ b/src/commands/scan-file-scope.ts
@@ -20,7 +20,7 @@ interface ScanFileScopeRequest {
 	readonly rootDirectory: string;
 }
 
-interface ScanFileScope {
+export interface ScanFileScope {
 	readonly dependencyAuditFiles: string[];
 	readonly dependencyAuditScope: "files" | "full";
 	readonly files: string[];

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -11,7 +11,9 @@ import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
 import { renderDisplayRows } from "../ui/display.js";
 import { renderHeader } from "../ui/header.js";
 import { log } from "../ui/logger.js";
+import { applyChangeContext } from "../utils/change-context.js";
 import { detectSourceLanguages, discoverProject, type Language } from "../utils/discover.js";
+import { getChangedLineMap } from "../utils/git.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
@@ -165,10 +167,22 @@ const runScanBody = async (
 		...result,
 		diagnostics: applyRuleSeverities(result.diagnostics, config.rules),
 	}));
-	const { results, suppressedCount } = applySuppressions(severityAdjusted, resolvedDir);
+	const { results: unannotated, suppressedCount } = applySuppressions(
+		severityAdjusted,
+		resolvedDir,
+	);
 	if (suppressedCount > 0 && !machineOutput) {
 		log.muted(`Suppressed ${suppressedCount} finding(s) via aislop-ignore directives`);
 	}
+
+	const classifyChanges = options.changes && !options.staged;
+	const changeMap = classifyChanges ? getChangedLineMap(resolvedDir, options.base) : null;
+	const results = changeMap
+		? unannotated.map((result) => ({
+				...result,
+				diagnostics: applyChangeContext(result.diagnostics, changeMap, resolvedDir),
+			}))
+		: unannotated;
 
 	const allDiagnostics = results.flatMap((r) => r.diagnostics);
 	const elapsedMs = performance.now() - startTime;

--- a/src/engines/code-quality/knip.ts
+++ b/src/engines/code-quality/knip.ts
@@ -289,9 +289,13 @@ export const runKnipUnusedFiles = async (rootDirectory: string): Promise<Diagnos
 	return all.filter((d) => d.rule === "knip/files");
 };
 
-export const fixUnusedFiles = async (rootDirectory: string): Promise<void> => {
+export const fixUnusedFiles = async (
+	rootDirectory: string,
+	allow: (filePath: string) => boolean = () => true,
+): Promise<void> => {
 	const diagnostics = await runKnipUnusedFiles(rootDirectory);
 	for (const d of diagnostics) {
+		if (!allow(d.filePath)) continue;
 		const absolutePath = getSafeUnusedFilePath(rootDirectory, d.filePath);
 		if (absolutePath) {
 			fs.unlinkSync(absolutePath);

--- a/src/engines/format/dotnet-format.ts
+++ b/src/engines/format/dotnet-format.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import micromatch from "micromatch";
 import { normalizeExcludePatterns } from "../../utils/exclude.js";
@@ -68,7 +69,16 @@ export const parseDotnetFormatReport = (json: string, rootDirectory: string): Di
 	return diagnostics;
 };
 
-const reportPathFor = (rootDirectory: string): string => path.join(rootDirectory, REPORT_FILENAME);
+// The report is scratch state, so it lives outside the tree. Writing it into the
+// project meant an unconditional delete of that path, destroying a same-named user file.
+const withReportPath = async <T>(run: (reportPath: string) => Promise<T>): Promise<T> => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-dotnet-format-"));
+	try {
+		return await run(path.join(dir, REPORT_FILENAME));
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+};
 
 // Syntax micromatch accepts that Microsoft.Extensions.FileSystemGlobbing does
 // not: character classes, extglobs, negation, and escapes have no equivalent,
@@ -118,37 +128,35 @@ const excludeOption = (scope: DotnetFormatExcludeScope): string[] =>
 // the check to the same excludes the fixer honors keeps a step's before/after
 // counts consistent; a pattern dotnet format cannot express is left to
 // filterExcludedDiagnostics, which reads nothing but the reported paths.
-const checkTarget = async (context: EngineContext, target: string): Promise<Diagnostic[]> => {
-	const reportPath = reportPathFor(context.rootDirectory);
-	const scope = buildDotnetFormatExcludeScope(context.excludePatterns);
-	try {
-		await runSubprocess(
-			"dotnet",
-			[
-				"format",
-				"whitespace",
-				target,
-				"--no-restore",
-				...excludeOption(scope),
-				"--verify-no-changes",
-				"--report",
-				reportPath,
-			],
-			{ cwd: context.rootDirectory, timeout: 180000 },
-		);
-		let json: string;
+const checkTarget = async (context: EngineContext, target: string): Promise<Diagnostic[]> =>
+	withReportPath(async (reportPath) => {
+		const scope = buildDotnetFormatExcludeScope(context.excludePatterns);
 		try {
-			json = fs.readFileSync(reportPath, "utf-8");
-			fs.rmSync(reportPath, { force: true });
+			await runSubprocess(
+				"dotnet",
+				[
+					"format",
+					"whitespace",
+					target,
+					"--no-restore",
+					...excludeOption(scope),
+					"--verify-no-changes",
+					"--report",
+					reportPath,
+				],
+				{ cwd: context.rootDirectory, timeout: 180000 },
+			);
+			let json: string;
+			try {
+				json = fs.readFileSync(reportPath, "utf-8");
+			} catch {
+				return [];
+			}
+			return parseDotnetFormatReport(json, context.rootDirectory);
 		} catch {
 			return [];
 		}
-		return parseDotnetFormatReport(json, context.rootDirectory);
-	} catch {
-		fs.rmSync(reportPath, { force: true });
-		return [];
-	}
-};
+	});
 
 export const runDotnetFormat = async (context: EngineContext): Promise<Diagnostic[]> => {
 	// Silent restore-evidence gate: the skip notice is the

--- a/src/engines/format/generic.ts
+++ b/src/engines/format/generic.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Language } from "../../utils/discover.js";
 import { projectRelativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
@@ -113,24 +114,55 @@ export const runGenericFormatter = async (
 
 		const output = result.stdout || result.stderr;
 		if (!output) return [];
-		return config.parseOutput(output, context.rootDirectory).map((diagnostic) => ({
+		const diagnostics = config.parseOutput(output, context.rootDirectory).map((diagnostic) => ({
 			...diagnostic,
 			filePath: projectRelativePosix(context.rootDirectory, diagnostic.filePath),
 		}));
+		if (!context.files) return diagnostics;
+		const allowed = new Set(relativeTargets(context, language));
+		return diagnostics.filter((diagnostic) => allowed.has(diagnostic.filePath));
 	} catch {
 		return [];
 	}
 };
 
+const LANGUAGE_EXTENSIONS: Partial<Record<Language, ReadonlySet<string>>> = {
+	rust: new Set([".rs"]),
+	ruby: new Set([".rb"]),
+	php: new Set([".php"]),
+};
+
+const relativeTargets = (context: EngineContext, language: Language): string[] => {
+	const extensions = LANGUAGE_EXTENSIONS[language];
+	if (!extensions || !context.files) return [];
+	return [
+		...new Set(
+			context.files
+				.filter((filePath) => extensions.has(path.extname(filePath).toLowerCase()))
+				.map((filePath) => projectRelativePosix(context.rootDirectory, filePath))
+				.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")),
+		),
+	];
+};
+
 export const fixGenericFormatter = async (
-	rootDirectory: string,
+	context: EngineContext,
 	language: Language,
 ): Promise<void> => {
 	const config = FORMATTERS[language];
 	if (!config) return;
+	const scoped = relativeTargets(context, language);
+	if (context.files && scoped.length === 0) return;
 
-	const result = await runSubprocess(config.command, config.fixArgs, {
-		cwd: rootDirectory,
+	const args =
+		language === "php" && context.files
+			? ["fix", ...scoped]
+			: context.files
+				? [...config.fixArgs, ...scoped]
+				: config.fixArgs;
+
+	const result = await runSubprocess(config.command, args, {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 

--- a/src/engines/format/gofmt.ts
+++ b/src/engines/format/gofmt.ts
@@ -1,10 +1,27 @@
+import path from "node:path";
 import { relativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
 import type { Diagnostic, EngineContext } from "../types.js";
 
+const GO_EXTENSIONS = new Set([".go"]);
+
+const gofmtTargets = (context: EngineContext): string[] => {
+	if (!context.files) return [context.rootDirectory];
+	return [
+		...new Set(
+			context.files
+				.filter((filePath) => GO_EXTENSIONS.has(path.extname(filePath).toLowerCase()))
+				.map((filePath) => relativePosix(context.rootDirectory, filePath))
+				.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")),
+		),
+	];
+};
+
 export const runGofmt = async (context: EngineContext): Promise<Diagnostic[]> => {
+	const targets = gofmtTargets(context);
+	if (targets.length === 0) return [];
 	try {
-		const result = await runSubprocess("gofmt", ["-l", context.rootDirectory], {
+		const result = await runSubprocess("gofmt", ["-l", ...targets], {
 			cwd: context.rootDirectory,
 			timeout: 60000,
 		});
@@ -29,9 +46,11 @@ export const runGofmt = async (context: EngineContext): Promise<Diagnostic[]> =>
 	}
 };
 
-export const fixGofmt = async (rootDirectory: string): Promise<void> => {
-	const result = await runSubprocess("gofmt", ["-w", rootDirectory], {
-		cwd: rootDirectory,
+export const fixGofmt = async (context: EngineContext): Promise<void> => {
+	const targets = gofmtTargets(context);
+	if (targets.length === 0) return;
+	const result = await runSubprocess("gofmt", ["-w", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {

--- a/src/engines/format/ruff-format.ts
+++ b/src/engines/format/ruff-format.ts
@@ -47,10 +47,12 @@ const parseRuffFormatOutput = (output: string, rootDir: string): Diagnostic[] =>
 	return diagnostics;
 };
 
-export const fixRuffFormat = async (rootDirectory: string): Promise<void> => {
+export const fixRuffFormat = async (context: EngineContext): Promise<void> => {
+	const targets = context.files ? getPythonTargets(context) : [context.rootDirectory];
+	if (context.files && targets.length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(ruffBinary, ["format", rootDirectory], {
-		cwd: rootDirectory,
+	const result = await runSubprocess(ruffBinary, ["format", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {

--- a/src/engines/lint/generic.ts
+++ b/src/engines/lint/generic.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Language } from "../../utils/discover.js";
 import { projectRelativePosix } from "../../utils/paths.js";
 import { runSubprocess } from "../../utils/subprocess.js";
@@ -18,15 +19,26 @@ export const runGenericLinter = async (
 		default:
 			return [];
 	}
-	return diagnostics.map((diagnostic) => ({
+	const normalized = diagnostics.map((diagnostic) => ({
 		...diagnostic,
 		filePath: projectRelativePosix(context.rootDirectory, diagnostic.filePath),
 	}));
+	if (!context.files) return normalized;
+	const allowed = new Set(
+		context.files.map((filePath) => projectRelativePosix(context.rootDirectory, filePath)),
+	);
+	return normalized.filter((diagnostic) => allowed.has(diagnostic.filePath));
 };
 
-export const fixRubyLint = async (rootDirectory: string): Promise<void> => {
-	const result = await runSubprocess("rubocop", ["-a", "--except", "Layout"], {
-		cwd: rootDirectory,
+export const fixRubyLint = async (context: EngineContext): Promise<void> => {
+	const targets =
+		context.files
+			?.filter((filePath) => path.extname(filePath).toLowerCase() === ".rb")
+			.map((filePath) => projectRelativePosix(context.rootDirectory, filePath))
+			.filter((filePath) => filePath.length > 0 && !filePath.startsWith("..")) ?? [];
+	if (context.files && targets.length === 0) return;
+	const result = await runSubprocess("rubocop", ["-a", "--except", "Layout", ...targets], {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 

--- a/src/engines/lint/ruff.ts
+++ b/src/engines/lint/ruff.ts
@@ -48,10 +48,19 @@ export const runRuffLint = async (
 	}
 };
 
-export const fixRuffLint = async (rootDirectory: string): Promise<void> => {
+const ruffLintFixArgs = (context: EngineContext, unsafe: boolean): string[] => {
+	const targets = context.files ? getPythonTargets(context) : [context.rootDirectory];
+	const args = ["check", "--fix"];
+	if (unsafe) args.push("--unsafe-fixes");
+	args.push(...targets);
+	return args;
+};
+
+export const fixRuffLint = async (context: EngineContext): Promise<void> => {
+	if (context.files && getPythonTargets(context).length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(ruffBinary, ["check", "--fix", rootDirectory], {
-		cwd: rootDirectory,
+	const result = await runSubprocess(ruffBinary, ruffLintFixArgs(context, false), {
+		cwd: context.rootDirectory,
 		timeout: 60000,
 	});
 	if (result.exitCode !== 0) {
@@ -61,16 +70,13 @@ export const fixRuffLint = async (rootDirectory: string): Promise<void> => {
 	}
 };
 
-export const fixRuffLintForce = async (rootDirectory: string): Promise<void> => {
+export const fixRuffLintForce = async (context: EngineContext): Promise<void> => {
+	if (context.files && getPythonTargets(context).length === 0) return;
 	const ruffBinary = resolveToolBinary("ruff");
-	const result = await runSubprocess(
-		ruffBinary,
-		["check", "--fix", "--unsafe-fixes", rootDirectory],
-		{
-			cwd: rootDirectory,
-			timeout: 60000,
-		},
-	);
+	const result = await runSubprocess(ruffBinary, ruffLintFixArgs(context, true), {
+		cwd: context.rootDirectory,
+		timeout: 60000,
+	});
 	if (result.exitCode !== 0) {
 		throw new Error(
 			result.stderr || result.stdout || `ruff check --fix exited with code ${result.exitCode}`,

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -10,6 +10,8 @@ export type EngineName =
 	| "architecture"
 	| "security";
 
+export type ChangeContext = "changed-line" | "existing-file-context" | "unknown";
+
 export interface Diagnostic {
 	filePath: string;
 	engine: EngineName;
@@ -22,6 +24,7 @@ export interface Diagnostic {
 	category: string;
 	fixable: boolean;
 	detail?: string;
+	changeContext?: ChangeContext;
 }
 
 export interface EngineResult {

--- a/src/output/sarif.ts
+++ b/src/output/sarif.ts
@@ -27,6 +27,7 @@ interface SarifResult {
 			region: { startLine: number; startColumn: number };
 		};
 	}>;
+	properties?: { changeContext: string };
 }
 
 interface SarifLog {
@@ -88,6 +89,7 @@ export const buildSarifLog = (results: EngineResult[]): SarifLog => {
 				},
 			},
 		],
+		...(d.changeContext ? { properties: { changeContext: d.changeContext } } : {}),
 	}));
 
 	return {

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -1,8 +1,9 @@
-import type { Diagnostic, EngineResult } from "../engines/types.js";
+import type { ChangeContext, Diagnostic, EngineResult } from "../engines/types.js";
 import { highlightAislop } from "../ui/brand.js";
 import { log } from "../ui/logger.js";
 import { symbols } from "../ui/symbols.js";
 import { style, theme } from "../ui/theme.js";
+import { changeContextOrder } from "../utils/change-context.js";
 import { getEngineLabel } from "./engine-info.js";
 
 const groupBy = <T>(items: T[], key: (item: T) => string): Map<string, T[]> => {
@@ -146,8 +147,13 @@ const renderHiddenFooter = (
 	lines.push("");
 };
 
-export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): string => {
-	const lines: string[] = [];
+const CHANGE_CONTEXT_HEADING: Record<ChangeContext, string> = {
+	"changed-line": "Changed lines",
+	"existing-file-context": "Existing file context",
+	unknown: "Unclassified",
+};
+
+const renderEngineGroups = (diagnostics: Diagnostic[], verbose: boolean, lines: string[]): void => {
 	const byEngine = groupBy(diagnostics, (d) => d.engine);
 
 	for (const [engine, engineDiags] of byEngine) {
@@ -175,6 +181,34 @@ export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): 
 		}
 
 		if (sorted.length > maxRules) renderHiddenFooter(sorted, maxRules, lines);
+	}
+};
+
+export const renderDiagnostics = (diagnostics: Diagnostic[], verbose: boolean): string => {
+	const lines: string[] = [];
+	const classified = diagnostics.some((diagnostic) => diagnostic.changeContext);
+	if (!classified) {
+		renderEngineGroups(diagnostics, verbose, lines);
+		return `${lines.join("\n")}\n`;
+	}
+
+	const partitions = new Map<ChangeContext, Diagnostic[]>();
+	for (const diagnostic of [...diagnostics].sort(
+		(left, right) =>
+			changeContextOrder(left.changeContext) - changeContextOrder(right.changeContext),
+	)) {
+		const key = diagnostic.changeContext ?? "unknown";
+		const group = partitions.get(key) ?? [];
+		group.push(diagnostic);
+		partitions.set(key, group);
+	}
+
+	const order: ChangeContext[] = ["changed-line", "existing-file-context", "unknown"];
+	for (const key of order) {
+		const group = partitions.get(key);
+		if (!group || group.length === 0) continue;
+		lines.push(`  ${style(theme, "section", CHANGE_CONTEXT_HEADING[key])}`);
+		renderEngineGroups(group, verbose, lines);
 	}
 
 	return `${lines.join("\n")}\n`;

--- a/src/ui/agent-tui/Sidebar.tsx
+++ b/src/ui/agent-tui/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
 import { computeCostUsd, resolvePricing } from "../../agents/pricing.js";
 import type { AgentSessionState } from "../../agents/session-state.js";
 import { fmtElapsed, fmtTokens } from "./format.js";
@@ -19,7 +20,21 @@ const scoreColor = (score: number | null, target: number): string => {
 	return "red";
 };
 
+// Reading the clock during render makes the component impure and, with nothing
+// driving a re-render, leaves elapsed stale until an unrelated update happens.
+const useElapsedSince = (startedAt: number): number => {
+	const [now, setNow] = useState(startedAt);
+	useEffect(() => {
+		const tick = () => setNow(Date.now());
+		tick();
+		const timer = setInterval(tick, 1000);
+		return () => clearInterval(timer);
+	}, []);
+	return Math.max(0, now - startedAt);
+};
+
 export const Sidebar = ({ state }: { state: AgentSessionState }) => {
+	const elapsed = useElapsedSince(state.startedAt);
 	const pricing = resolvePricing(state.provider, state.model);
 	const cost = state.usage?.costUsd ?? computeCostUsd(pricing, state.tokens);
 	// Context is the share of the model window the current turn occupies, so it
@@ -66,7 +81,7 @@ export const Sidebar = ({ state }: { state: AgentSessionState }) => {
 				/>
 				{hasUsage && cost != null ? <Row label="Cost" value={`$${cost.toFixed(2)}`} /> : null}
 				{hasUsage && ctx != null ? <Row label="Context" value={`${Math.round(ctx)}%`} /> : null}
-				<Row label="Elapsed" value={fmtElapsed(Date.now() - state.startedAt)} />
+				<Row label="Elapsed" value={fmtElapsed(elapsed)} />
 			</Box>
 		</Box>
 	);

--- a/src/ui/command-reference-data.ts
+++ b/src/ui/command-reference-data.ts
@@ -42,6 +42,9 @@ const FIX_FLAGS = [
 	"-f, --force",
 	"--safe",
 	"--dry-run",
+	"--changes",
+	"--staged",
+	"--base <ref>",
 	"-p, --prompt",
 	...FIX_AGENT_FLAGS,
 ];

--- a/src/ui/command-reference-data.ts
+++ b/src/ui/command-reference-data.ts
@@ -37,7 +37,14 @@ const FIX_AGENT_FLAGS = [
 	"--crush",
 ];
 
-const FIX_FLAGS = ["-d, --verbose", "-f, --force", "--safe", "-p, --prompt", ...FIX_AGENT_FLAGS];
+const FIX_FLAGS = [
+	"-d, --verbose",
+	"-f, --force",
+	"--safe",
+	"--dry-run",
+	"-p, --prompt",
+	...FIX_AGENT_FLAGS,
+];
 
 const AGENT_FLAGS = [
 	"--provider <provider>",

--- a/src/utils/change-context.ts
+++ b/src/utils/change-context.ts
@@ -1,0 +1,98 @@
+import type { ChangeContext, Diagnostic } from "../engines/types.js";
+import { projectRelativePosix, toPosix } from "./paths.js";
+
+export type ChangedLines =
+	| { readonly kind: "all" }
+	| { readonly kind: "hunks"; readonly ranges: ReadonlyArray<{ start: number; end: number }> };
+
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+const stripDiffPrefix = (filePath: string): string => {
+	if (filePath === "/dev/null") return filePath;
+	return filePath.replace(/^[ab]\//, "");
+};
+
+const parseHunkRange = (
+	startText: string,
+	countText: string | undefined,
+): { start: number; end: number } | null => {
+	const start = Number(startText);
+	const count = countText === undefined ? 1 : Number(countText);
+	if (!Number.isFinite(start) || !Number.isFinite(count) || count <= 0) return null;
+	return { start, end: start + count - 1 };
+};
+
+export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> => {
+	const byFile = new Map<string, { start: number; end: number }[]>();
+	let current: string | null = null;
+
+	for (const raw of diff.split(/\r?\n/)) {
+		if (raw.startsWith("rename to ")) {
+			current = toPosix(raw.slice("rename to ".length).trim());
+			if (current && !byFile.has(current)) byFile.set(current, []);
+			continue;
+		}
+		if (raw.startsWith("+++ ")) {
+			const name = stripDiffPrefix(raw.slice(4).trim());
+			current = name === "/dev/null" ? null : toPosix(name);
+			if (current && !byFile.has(current)) byFile.set(current, []);
+			continue;
+		}
+		if (!current) continue;
+		const match = HUNK_RE.exec(raw);
+		if (!match) continue;
+		const range = parseHunkRange(match[3], match[4]);
+		if (!range) continue;
+		const ranges = byFile.get(current);
+		if (ranges) ranges.push(range);
+	}
+
+	const result = new Map<string, ChangedLines>();
+	for (const [filePath, ranges] of byFile) {
+		result.set(filePath, { kind: "hunks", ranges });
+	}
+	return result;
+};
+
+const lookupChangedLines = (
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+	filePath: string,
+): ChangedLines | undefined => {
+	const slashPath = filePath.split("\\").join("/");
+	const relative = projectRelativePosix(rootDirectory, slashPath);
+	return map.get(relative) ?? map.get(toPosix(slashPath)) ?? map.get(slashPath);
+};
+
+export const classifyChangeContext = (
+	diagnostic: Diagnostic,
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+): ChangeContext => {
+	if (diagnostic.line <= 0) return "unknown";
+	const entry = lookupChangedLines(map, rootDirectory, diagnostic.filePath);
+	if (!entry) return "unknown";
+	if (entry.kind === "all") return "changed-line";
+	if (
+		entry.ranges.some((range) => diagnostic.line >= range.start && diagnostic.line <= range.end)
+	) {
+		return "changed-line";
+	}
+	return "existing-file-context";
+};
+
+export const applyChangeContext = (
+	diagnostics: Diagnostic[],
+	map: Map<string, ChangedLines>,
+	rootDirectory: string,
+): Diagnostic[] =>
+	diagnostics.map((diagnostic) => ({
+		...diagnostic,
+		changeContext: classifyChangeContext(diagnostic, map, rootDirectory),
+	}));
+
+export const changeContextOrder = (context: ChangeContext | undefined): number => {
+	if (context === "changed-line") return 0;
+	if (context === "existing-file-context") return 1;
+	return 2;
+};

--- a/src/utils/change-context.ts
+++ b/src/utils/change-context.ts
@@ -22,17 +22,27 @@ const parseHunkRange = (
 	return { start, end: start + count - 1 };
 };
 
+// git writes "+++ a/path", "+++ b/path" or "+++ /dev/null"; a bare "+++ " is content.
+const FILE_HEADER_RE = /^\+\+\+ (?:[ab]\/|\/dev\/null$)/;
+
 export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> => {
 	const byFile = new Map<string, { start: number; end: number }[]>();
 	let current: string | null = null;
 
+	// Inside a hunk body an added line is written "+<content>", so content beginning with
+	// "++ " reproduces a "+++ " header. Only trust the header before the first hunk.
+	let inHunkBody = false;
+
 	for (const raw of diff.split(/\r?\n/)) {
+		if (raw.startsWith("diff --git ") || raw.startsWith("rename to ")) {
+			inHunkBody = false;
+		}
 		if (raw.startsWith("rename to ")) {
 			current = toPosix(raw.slice("rename to ".length).trim());
 			if (current && !byFile.has(current)) byFile.set(current, []);
 			continue;
 		}
-		if (raw.startsWith("+++ ")) {
+		if (!inHunkBody && FILE_HEADER_RE.test(raw)) {
 			const name = stripDiffPrefix(raw.slice(4).trim());
 			current = name === "/dev/null" ? null : toPosix(name);
 			if (current && !byFile.has(current)) byFile.set(current, []);
@@ -40,7 +50,10 @@ export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> =
 		}
 		if (!current) continue;
 		const match = HUNK_RE.exec(raw);
-		if (!match) continue;
+		if (!match) {
+			continue;
+		}
+		inHunkBody = true;
 		const range = parseHunkRange(match[3], match[4]);
 		if (!range) continue;
 		const ranges = byFile.get(current);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { type ChangedLines, parseUnifiedDiffHunks } from "./change-context.js";
+import { projectRelativePosix } from "./paths.js";
 
 const MAX_BUFFER = 50 * 1024 * 1024;
 
@@ -52,4 +54,28 @@ export const getStagedFiles = (cwd: string): string[] => {
 		.split("\n")
 		.filter((f) => f.length > 0)
 		.map((f) => path.resolve(cwd, f));
+};
+
+const listUntrackedFiles = (cwd: string): string[] => {
+	const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: MAX_BUFFER,
+	});
+	if (untracked.error || untracked.status !== 0) return [];
+	return untracked.stdout.split("\n").filter((line) => line.length > 0);
+};
+
+export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
+	const baseRef = base ?? "HEAD";
+	const diff = spawnSync("git", ["diff", "-U0", "--diff-filter=ACMR", baseRef], {
+		cwd,
+		encoding: "utf-8",
+		maxBuffer: MAX_BUFFER,
+	});
+	const map = !diff.error && diff.status === 0 ? parseUnifiedDiffHunks(diff.stdout) : new Map();
+	for (const name of listUntrackedFiles(cwd)) {
+		map.set(projectRelativePosix(cwd, path.resolve(cwd, name)), { kind: "all" });
+	}
+	return map;
 };

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -17,11 +17,15 @@ export const baseRefExists = (cwd: string, ref: string): boolean => {
 
 export const getChangedFiles = (cwd: string, base?: string): string[] => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const diff = spawnSync(
+		"git",
+		["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	if (diff.error || diff.status !== 0) return [];
 
 	const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
@@ -44,11 +48,15 @@ export const getChangedFiles = (cwd: string, base?: string): string[] => {
 };
 
 export const getStagedFiles = (cwd: string): string[] => {
-	const result = spawnSync("git", ["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const result = spawnSync(
+		"git",
+		["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	if (result.error || result.status !== 0) return [];
 	return result.stdout
 		.split("\n")
@@ -68,11 +76,15 @@ const listUntrackedFiles = (cwd: string): string[] => {
 
 export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--no-color", "-U0", "--diff-filter=ACMR", baseRef], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const diff = spawnSync(
+		"git",
+		["diff", "--no-color", "--no-ext-diff", "-U0", "--diff-filter=ACMR", baseRef],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	const map = !diff.error && diff.status === 0 ? parseUnifiedDiffHunks(diff.stdout) : new Map();
 	for (const name of listUntrackedFiles(cwd)) {
 		map.set(projectRelativePosix(cwd, path.resolve(cwd, name)), { kind: "all" });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -17,7 +17,7 @@ export const baseRefExists = (cwd: string, ref: string): boolean => {
 
 export const getChangedFiles = (cwd: string, base?: string): string[] => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--name-only", "--diff-filter=ACMR", baseRef], {
+	const diff = spawnSync("git", ["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,
@@ -44,7 +44,7 @@ export const getChangedFiles = (cwd: string, base?: string): string[] => {
 };
 
 export const getStagedFiles = (cwd: string): string[] => {
-	const result = spawnSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMR"], {
+	const result = spawnSync("git", ["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,
@@ -68,7 +68,7 @@ const listUntrackedFiles = (cwd: string): string[] => {
 
 export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "-U0", "--diff-filter=ACMR", baseRef], {
+	const diff = spawnSync("git", ["diff", "--no-color", "-U0", "--diff-filter=ACMR", baseRef], {
 		cwd,
 		encoding: "utf-8",
 		maxBuffer: MAX_BUFFER,

--- a/tests/ci-changes-base.test.ts
+++ b/tests/ci-changes-base.test.ts
@@ -76,4 +76,32 @@ describe("ci --changes --base", () => {
 		const parsed = JSON.parse(res.stdout) as { error?: string };
 		expect(parsed.error).toMatch(/does-not-exist/);
 	});
+
+	it("classifies new-line findings vs existing-file context without hiding either", () => {
+		write(tmpDir, "tainted.ts", `${SECRET}export const extra = 1 as any;\n`);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "edit", "--no-verify"]);
+		const scoped = runCli(["scan", tmpDir, "--changes", "--base", baseSha, "--json"]);
+		const parsed = JSON.parse(scoped.stdout) as {
+			diagnostics?: Array<{ rule: string; line: number; changeContext?: string }>;
+		};
+		const byRule = new Map((parsed.diagnostics ?? []).map((d) => [d.rule, d]));
+		expect(byRule.get("security/hardcoded-secret")?.changeContext).toBe("existing-file-context");
+		expect(byRule.get("ai-slop/unsafe-type-assertion")?.changeContext).toBe("changed-line");
+	});
+
+	it("does not classify full scans or staged scans", () => {
+		write(tmpDir, "clean.ts", `${CLEAN}export const extra = 1 as any;\n`);
+		git(tmpDir, ["add", "clean.ts"]);
+		const full = runCli(["scan", tmpDir, "--json"]);
+		const staged = runCli(["scan", tmpDir, "--staged", "--json"]);
+		const fullDiag = (
+			JSON.parse(full.stdout) as { diagnostics?: Array<{ changeContext?: string }> }
+		).diagnostics?.[0];
+		const stagedDiag = (
+			JSON.parse(staged.stdout) as { diagnostics?: Array<{ changeContext?: string }> }
+		).diagnostics?.[0];
+		expect(fullDiag?.changeContext).toBeUndefined();
+		expect(stagedDiag?.changeContext).toBeUndefined();
+	});
 });

--- a/tests/ci-changes-base.test.ts
+++ b/tests/ci-changes-base.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
+import { isPathInFixScope } from "../src/commands/fix-scope.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
+import type { EngineContext } from "../src/engines/types.js";
 
 const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
 
@@ -75,5 +80,186 @@ describe("ci --changes --base", () => {
 		expect(res.status).not.toBe(0);
 		const parsed = JSON.parse(res.stdout) as { error?: string };
 		expect(parsed.error).toMatch(/does-not-exist/);
+	});
+});
+
+const UNUSED_IMPORT = 'import { leftover } from "./missing";\nexport const value = 1;\n';
+const FIXED_IMPORT = "export const value = 1;\n";
+
+const slopConfig = (): AislopConfig => ({
+	...DEFAULT_CONFIG,
+	engines: {
+		...DEFAULT_CONFIG.engines,
+		format: false,
+		lint: false,
+		"code-quality": false,
+		architecture: false,
+		security: false,
+		"ai-slop": true,
+	},
+	telemetry: { enabled: false },
+});
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+const posixRel = (root: string, rel: string): string =>
+	fs.readFileSync(path.join(root, ...rel.split("/")), "utf-8");
+
+describe("fix --changes --base", () => {
+	let tmpDir = "";
+	let baseSha = "";
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-"));
+		git(tmpDir, ["init"]);
+		git(tmpDir, ["config", "user.email", "test@example.com"]);
+		git(tmpDir, ["config", "user.name", "test"]);
+		git(tmpDir, ["config", "commit.gpgsign", "false"]);
+		write(tmpDir, "untouched.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "base", "--no-verify"]);
+		baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: tmpDir,
+			encoding: "utf8",
+		}).trim();
+		git(tmpDir, ["checkout", "-b", "feature"]);
+		write(tmpDir, "changed.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "feat", "--no-verify"]);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("does not rewrite files outside the selected change set", async () => {
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				changes: true,
+				base: baseSha,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("includes untracked files using the same semantics as scan --changes", async () => {
+		write(tmpDir, "fresh.ts", UNUSED_IMPORT);
+		write(tmpDir, "notes.txt", "leave me alone\n");
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				changes: true,
+				base: baseSha,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "fresh.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "notes.txt")).toBe("leave me alone\n");
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("fails when --changes and --staged are combined", async () => {
+		const result = await fixCommand(tmpDir, slopConfig(), {
+			verbose: false,
+			changes: true,
+			staged: true,
+			showHeader: false,
+		});
+		expect(result.exitCode).toBe(1);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(UNUSED_IMPORT);
+		expect(posixRel(tmpDir, "untouched.ts")).toBe(UNUSED_IMPORT);
+	});
+
+	it("fails when an explicit --base ref cannot be resolved", async () => {
+		const result = await fixCommand(tmpDir, slopConfig(), {
+			verbose: false,
+			changes: true,
+			base: "origin/does-not-exist",
+			showHeader: false,
+		});
+		expect(result.exitCode).toBe(1);
+		expect(posixRel(tmpDir, "changed.ts")).toBe(UNUSED_IMPORT);
+	});
+});
+
+describe("fix --staged", () => {
+	let tmpDir = "";
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-staged-"));
+		git(tmpDir, ["init"]);
+		git(tmpDir, ["config", "user.email", "test@example.com"]);
+		git(tmpDir, ["config", "user.name", "test"]);
+		git(tmpDir, ["config", "commit.gpgsign", "false"]);
+		write(tmpDir, "committed.ts", FIXED_IMPORT);
+		git(tmpDir, ["add", "."]);
+		git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rewrites staged files only and leaves unstaged and untracked files alone", async () => {
+		write(tmpDir, "staged.ts", UNUSED_IMPORT);
+		git(tmpDir, ["add", "staged.ts"]);
+		write(tmpDir, "unstaged.ts", UNUSED_IMPORT);
+		write(tmpDir, "committed.ts", UNUSED_IMPORT);
+		await captureStdout(() =>
+			fixCommand(tmpDir, slopConfig(), {
+				verbose: false,
+				staged: true,
+				showHeader: false,
+			}),
+		);
+		expect(posixRel(tmpDir, "staged.ts")).toBe(FIXED_IMPORT);
+		expect(posixRel(tmpDir, "unstaged.ts")).toBe(UNUSED_IMPORT);
+		expect(posixRel(tmpDir, "committed.ts")).toBe(UNUSED_IMPORT);
+	});
+});
+
+describe("fix scope path normalization", () => {
+	it("treats OS-native and POSIX-relative paths as the same file", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-paths-"));
+		try {
+			const nativeFile = path.join(root, "src", "app.ts");
+			const context = {
+				rootDirectory: root,
+				languages: ["typescript"],
+				frameworks: ["none"],
+				files: [nativeFile],
+				installedTools: {},
+				config: {
+					quality: DEFAULT_CONFIG.quality,
+					security: DEFAULT_CONFIG.security,
+					lint: DEFAULT_CONFIG.lint,
+				},
+			} as EngineContext;
+			expect(isPathInFixScope(context, nativeFile)).toBe(true);
+			expect(isPathInFixScope(context, "src/app.ts")).toBe(true);
+			expect(isPathInFixScope(context, path.join(root, "src", "other.ts"))).toBe(false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -228,6 +228,9 @@ describe("cli ergonomics", () => {
 		expect(fix.stdout).toContain("Auto-fix findings or hand off to a coding agent");
 		expect(fix.stdout).toContain("--safe");
 		expect(fix.stdout).toContain("--dry-run");
+		expect(fix.stdout).toContain("--changes");
+		expect(fix.stdout).toContain("--staged");
+		expect(fix.stdout).toContain("--base <ref>");
 		expect(fix.stdout).toContain("--claude");
 		expect(fix.stdout).toContain("--codex");
 		expect(fix.stdout).toContain("--opencode");

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -227,6 +227,7 @@ describe("cli ergonomics", () => {
 		expect(fix.status).toBe(0);
 		expect(fix.stdout).toContain("Auto-fix findings or hand off to a coding agent");
 		expect(fix.stdout).toContain("--safe");
+		expect(fix.stdout).toContain("--dry-run");
 		expect(fix.stdout).toContain("--claude");
 		expect(fix.stdout).toContain("--codex");
 		expect(fix.stdout).toContain("--opencode");

--- a/tests/dotnet-format.test.ts
+++ b/tests/dotnet-format.test.ts
@@ -105,6 +105,22 @@ describe("runDotnetFormat restore-evidence gating", () => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
+	it("leaves a user file named like the report alone", async () => {
+		// The report used to be written into the project root and deleted on every path,
+		// so a file a user happened to own at that name was destroyed by a scan.
+		const warmDir = path.join(tmpDir, "Warm");
+		fs.mkdirSync(path.join(warmDir, "obj"), { recursive: true });
+		fs.writeFileSync(path.join(warmDir, "Warm.csproj"), "");
+		fs.writeFileSync(path.join(warmDir, "obj", "project.assets.json"), "{}");
+		const userFile = path.join(tmpDir, ".aislop-dotnet-format.json");
+		fs.writeFileSync(userFile, '{"mine":true}');
+
+		await runDotnetFormat(formatContext(tmpDir));
+
+		expect(fs.existsSync(userFile)).toBe(true);
+		expect(fs.readFileSync(userFile, "utf-8")).toBe('{"mine":true}');
+	});
+
 	it("formats only projects with restore evidence, silently skipping cold ones", async () => {
 		const warmDir = path.join(tmpDir, "Warm");
 		fs.mkdirSync(path.join(warmDir, "obj"), { recursive: true });

--- a/tests/fix-force.test.ts
+++ b/tests/fix-force.test.ts
@@ -1,7 +1,9 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
 import {
 	collectPnpmOverrides,
 	guardOverrides,
@@ -12,6 +14,9 @@ import {
 	patchedRangeToVersion,
 	readInstalledVersions,
 } from "../src/commands/fix-force.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
 
 describe("patchedRangeToVersion", () => {
 	it("handles a simple >=", () => {
@@ -215,5 +220,106 @@ describe("readInstalledVersions", () => {
 
 	it("omits packages that are not installed anywhere", () => {
 		expect(readInstalledVersions(tmpDir, ["missing"]).has("missing")).toBe(false);
+	});
+});
+
+const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+describe("fix --dry-run --force", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("reports aggressive steps without mutating manifests, lockfiles, or dependencies", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-force-dry-run-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		const packageJson = `${JSON.stringify({ name: "force-preview", version: "1.0.0" }, null, 2)}\n`;
+		const lockfile = "lockfile-must-not-change\n";
+		fs.writeFileSync(path.join(root, "package.json"), packageJson);
+		fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), lockfile);
+		fs.mkdirSync(path.join(root, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(root, "src/app.ts"),
+			'import { leftover } from "./missing";\nexport const value = 1;\n',
+		);
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "init", "--no-verify"]);
+		const before = posixTree(root);
+		const statusBefore = execFileSync("git", ["status", "--porcelain", "-uall"], {
+			cwd: root,
+			encoding: "utf-8",
+		});
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: {
+				...DEFAULT_CONFIG.engines,
+				format: false,
+				lint: false,
+				architecture: false,
+				security: false,
+				"code-quality": true,
+				"ai-slop": true,
+			},
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, { verbose: false, dryRun: true, force: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Remove unused files");
+		expect(output).toContain("Dependency audit fixes");
+		expect(output).not.toContain("running pnpm");
+		expect(output).not.toContain("npm audit");
+		expect(output).not.toContain("expo install");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+		expect(fs.readFileSync(path.join(root, "package.json"), "utf-8")).toBe(packageJson);
+		expect(fs.readFileSync(path.join(root, "pnpm-lock.yaml"), "utf-8")).toBe(lockfile);
+		expect(
+			execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" }),
+		).toBe(statusBefore);
 	});
 });

--- a/tests/fix-plan.test.ts
+++ b/tests/fix-plan.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { buildFixStepNames } from "../src/commands/fix-plan.js";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
+import { buildFixPlan, buildFixStepNames } from "../src/commands/fix-plan.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
+import { runOneFixStep } from "../src/commands/fix-steps.js";
 import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { AislopConfig } from "../src/config/index.js";
+import type { Diagnostic } from "../src/engines/types.js";
 import type { ProjectInfo } from "../src/utils/discover.js";
 
 const makeProjectInfo = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
@@ -137,5 +145,229 @@ describe("buildFixStepNames", () => {
 		};
 		const steps = buildFixStepNames(makeProjectInfo(), config, {});
 		expect(steps).toHaveLength(0);
+	});
+
+	it("includes duplicate-import and unused-declaration steps for JS/TS projects", () => {
+		const steps = buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, {});
+		expect(steps).toContain("Duplicate imports");
+		expect(steps).toContain("Unused declarations");
+	});
+
+	it("marks safe-incompatible steps as skipped by --safe", () => {
+		const plan = buildFixPlan(makeProjectInfo(), DEFAULT_CONFIG, { safe: true });
+		expect(plan.find((step) => step.name === "Narrative comments")?.status).toBe("planned");
+		expect(plan.find((step) => step.name === "Dead code & comments")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Unused declarations")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Lint fixes (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Unused dependencies")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, { safe: true })).not.toContain(
+			"Dead code & comments",
+		);
+	});
+
+	it("reports aggressive steps as skipped by --safe when both flags are set", () => {
+		const plan = buildFixPlan(makeProjectInfo(), DEFAULT_CONFIG, { safe: true, force: true });
+		expect(plan.find((step) => step.name === "Remove unused files")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(plan.find((step) => step.name === "Dependency audit fixes")).toMatchObject({
+			status: "skipped",
+			reason: "skipped by --safe",
+		});
+		expect(
+			buildFixStepNames(makeProjectInfo(), DEFAULT_CONFIG, { safe: true, force: true }),
+		).not.toContain("Remove unused files");
+	});
+
+	it("marks engine-gated steps as disabled in config", () => {
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: { ...DEFAULT_CONFIG.engines, lint: false, format: false },
+		};
+		const plan = buildFixPlan(makeProjectInfo(), config, {});
+		expect(plan.find((step) => step.name === "Lint fixes (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "disabled in config",
+		});
+		expect(plan.find((step) => step.name === "Formatting (js/ts)")).toMatchObject({
+			status: "skipped",
+			reason: "disabled in config",
+		});
+	});
+});
+
+const git = (cwd: string, args: string[]) => {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+const write = (root: string, rel: string, body: string) => {
+	const abs = path.join(root, rel);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, body, "utf-8");
+};
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const gitStatus = (root: string): string =>
+	execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" });
+
+const snapshot = (root: string) => ({ tree: posixTree(root), status: gitStatus(root) });
+
+const previewConfig = (): AislopConfig => ({
+	...DEFAULT_CONFIG,
+	engines: {
+		...DEFAULT_CONFIG.engines,
+		format: false,
+		lint: false,
+		"code-quality": false,
+		architecture: false,
+		security: false,
+		"ai-slop": true,
+	},
+	telemetry: { enabled: false },
+});
+
+const UNUSED = 'import { leftover } from "./missing";\nexport const value = 1;\n';
+const UNTRACKED = "untracked leftover that must not be touched\n";
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+const initPreviewRepo = (): string => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-dry-run-"));
+	git(root, ["init"]);
+	git(root, ["config", "user.email", "test@example.com"]);
+	git(root, ["config", "user.name", "test"]);
+	git(root, ["config", "commit.gpgsign", "false"]);
+	write(root, "src/app.ts", UNUSED);
+	git(root, ["add", "src/app.ts"]);
+	git(root, ["commit", "-m", "init", "--no-verify"]);
+	write(root, "notes.txt", UNTRACKED);
+	return root;
+};
+
+describe("runOneFixStep dry-run", () => {
+	it("never invokes the mutating fixer", async () => {
+		let applied = 0;
+		const finding: Diagnostic = {
+			filePath: "src/app.ts",
+			engine: "ai-slop",
+			rule: "ai-slop/unused-import",
+			severity: "warning",
+			message: "unused",
+			help: "",
+			line: 1,
+			column: 1,
+			category: "Imports",
+			fixable: true,
+		};
+		const result = await runOneFixStep(
+			"Unused imports",
+			async () => [finding],
+			async () => {
+				applied += 1;
+			},
+			{ dryRun: true },
+		);
+		expect(applied).toBe(0);
+		expect(result.resolvedIssues).toBe(0);
+		expect(result.beforeIssues).toBe(1);
+		expect(result.beforeFiles).toBe(1);
+	});
+});
+
+describe("fix --dry-run", () => {
+	const repos: string[] = [];
+
+	afterEach(() => {
+		for (const root of repos.splice(0)) {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("prints the plan and does not modify tracked, untracked, or git status", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		const before = snapshot(root);
+
+		const output = await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Unused imports");
+		expect(output).toMatch(/1 finding/);
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(snapshot(root)).toEqual(before);
+	});
+
+	it("is deterministic on an unchanged repository", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		const run = () =>
+			captureStdout(() =>
+				fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: true }),
+			);
+		const first = await run();
+		const second = await run();
+		expect(second).toBe(first);
+	});
+
+	it("leaves the unused import in place so a later applying run can still fix it", async () => {
+		const root = initPreviewRepo();
+		repos.push(root);
+		await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: true, showHeader: false }),
+		);
+		expect(fs.readFileSync(path.join(root, "src/app.ts"), "utf-8")).toBe(UNUSED);
+		await captureStdout(() =>
+			fixCommand(root, previewConfig(), { verbose: false, dryRun: false, showHeader: false }),
+		);
+		expect(fs.readFileSync(path.join(root, "src/app.ts"), "utf-8")).not.toBe(UNUSED);
+		expect(fs.readFileSync(path.join(root, "notes.txt"), "utf-8")).toBe(UNTRACKED);
 	});
 });

--- a/tests/fix-safe-mode.test.ts
+++ b/tests/fix-safe-mode.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fixCommand } from "../src/commands/fix.js";
 import type { PipelineDeps } from "../src/commands/fix-pipeline.js";
 import { runAiSlopSteps, runFormattingStep } from "../src/commands/fix-pipeline.js";
+import { NO_CHANGES_APPLIED } from "../src/commands/fix-render.js";
 import type { FixStepResult } from "../src/commands/fix-steps.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { AislopConfig } from "../src/config/index.js";
 
 const recordingDeps = (
@@ -86,5 +93,92 @@ describe("runFormattingStep safe mode", () => {
 		await runFormattingStep(deps);
 
 		expect(steps).toEqual(["Formatting (ruby)", "Formatting (php)"]);
+	});
+});
+
+const git = (cwd: string, args: string[]) => execFileSync("git", args, { cwd, stdio: "ignore" });
+
+const write = (root: string, rel: string, body: string) => {
+	const abs = path.join(root, rel);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, body, "utf-8");
+};
+
+const posixTree = (root: string): Record<string, string> => {
+	const files: Record<string, string> = {};
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git") continue;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+				continue;
+			}
+			files[path.relative(root, abs).split(path.sep).join("/")] = fs.readFileSync(abs, "utf-8");
+		}
+	};
+	walk(root);
+	return files;
+};
+
+const captureStdout = async (run: () => Promise<unknown>): Promise<string> => {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	const previousCi = process.env.CI;
+	process.env.CI = "1";
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await run();
+		return chunks.join("");
+	} finally {
+		process.stdout.write = original;
+		if (previousCi === undefined) delete process.env.CI;
+		else process.env.CI = previousCi;
+	}
+};
+
+describe("fix --dry-run --safe", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("lists steps skipped by --safe and does not write files", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-safe-dry-run-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		write(root, "src/app.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "init", "--no-verify"]);
+		const before = posixTree(root);
+		const statusBefore = execFileSync("git", ["status", "--porcelain", "-uall"], {
+			cwd: root,
+			encoding: "utf-8",
+		});
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, { verbose: false, dryRun: true, safe: true, showHeader: true }),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("skipped by --safe");
+		expect(output).toContain("Dead code & comments");
+		expect(output).toContain("Unused declarations");
+		expect(output).toContain("Lint fixes (js/ts)");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+		expect(
+			execFileSync("git", ["status", "--porcelain", "-uall"], { cwd: root, encoding: "utf-8" }),
+		).toBe(statusBefore);
 	});
 });

--- a/tests/fix-safe-mode.test.ts
+++ b/tests/fix-safe-mode.test.ts
@@ -182,3 +182,59 @@ describe("fix --dry-run --safe", () => {
 		).toBe(statusBefore);
 	});
 });
+
+describe("fix --dry-run --changes", () => {
+	let root = "";
+
+	afterEach(() => {
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("previews only the selected change set and still writes nothing", async () => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-dry-run-changes-"));
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "test"]);
+		git(root, ["config", "commit.gpgsign", "false"]);
+		write(root, "untouched.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "base", "--no-verify"]);
+		const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: root,
+			encoding: "utf-8",
+		}).trim();
+		write(root, "changed.ts", 'import { leftover } from "./missing";\nexport const value = 1;\n');
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "feat", "--no-verify"]);
+		const before = posixTree(root);
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			engines: {
+				...DEFAULT_CONFIG.engines,
+				format: false,
+				lint: false,
+				"code-quality": false,
+				architecture: false,
+				security: false,
+				"ai-slop": true,
+			},
+			telemetry: { enabled: false },
+		};
+		const output = await captureStdout(() =>
+			fixCommand(root, config, {
+				verbose: false,
+				dryRun: true,
+				changes: true,
+				base: baseSha,
+				showHeader: true,
+			}),
+		);
+
+		expect(output).toContain("Fix plan");
+		expect(output).toContain("Scope");
+		expect(output).toContain("changed vs");
+		expect(output).toContain(NO_CHANGES_APPLIED);
+		expect(posixTree(root)).toEqual(before);
+	});
+});

--- a/tests/fix-scope-manifest.test.ts
+++ b/tests/fix-scope-manifest.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEngineContext } from "../src/commands/fix-context.js";
+import { scopeIncludesManifestWrites } from "../src/commands/fix-scope.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { EngineContext } from "../src/engines/types.js";
+
+let tmpDir: string;
+
+const contextFor = (files?: string[]): EngineContext =>
+	({
+		rootDirectory: tmpDir,
+		languages: ["typescript"],
+		frameworks: [],
+		files: files?.map((name) => path.join(tmpDir, name)),
+		installedTools: {},
+		config: {
+			quality: { maxFunctionLoc: 80, maxFileLoc: 400, maxNesting: 5, maxParams: 6 },
+			security: { audit: false, auditTimeout: 0 },
+		},
+	}) as unknown as EngineContext;
+
+const write = (name: string): void => fs.writeFileSync(path.join(tmpDir, name), "{}");
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-fix-scope-"));
+	write("package.json");
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("scopeIncludesManifestWrites", () => {
+	it("allows an unscoped fix", () => {
+		expect(scopeIncludesManifestWrites(contextFor())).toBe(true);
+	});
+
+	it("refuses when a lockfile is selected but the manifest the fixer rewrites is not", () => {
+		// The dependency fixers always rewrite package.json. Selecting only the lockfile
+		// used to pass the gate, letting a fix edit a file outside the chosen change set.
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["pnpm-lock.yaml", "src/app.ts"]))).toBe(false);
+	});
+
+	it("refuses when the manifest is selected but a lockfile it rewrites is not", () => {
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["package.json"]))).toBe(false);
+	});
+
+	it("allows when every file the fixer writes is selected", () => {
+		write("pnpm-lock.yaml");
+
+		expect(scopeIncludesManifestWrites(contextFor(["package.json", "pnpm-lock.yaml"]))).toBe(true);
+	});
+
+	it("ignores lockfiles the project does not have", () => {
+		expect(scopeIncludesManifestWrites(contextFor(["package.json"]))).toBe(true);
+	});
+});
+
+describe("manifest-only scopes keep project languages for dependency work", () => {
+	it("carries the project languages even when the selection has no source file", () => {
+		// detectSourceLanguages sees only package.json here and returns nothing, which used
+		// to make every dependency fixer skip a scope that explicitly selected the manifest.
+		const scopedProjectInfo = {
+			languages: [],
+			frameworks: [],
+			installedTools: {},
+		} as unknown as Parameters<typeof createEngineContext>[1];
+
+		const context = createEngineContext(tmpDir, scopedProjectInfo, DEFAULT_CONFIG, {
+			scope: {
+				files: [path.join(tmpDir, "package.json")],
+				testFiles: [],
+				projectFiles: [],
+				dependencyAuditFiles: [path.join(tmpDir, "package.json")],
+				dependencyAuditScope: "scoped",
+				scopeLabel: "changed files",
+			} as unknown as Parameters<typeof createEngineContext>[3]["scope"],
+			dependencyAuditLanguages: ["typescript"],
+		});
+
+		expect(context.languages).toEqual([]);
+		expect(context.dependencyAuditLanguages).toEqual(["typescript"]);
+	});
+});

--- a/tests/fix-scope-manifest.test.ts
+++ b/tests/fix-scope-manifest.test.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
 import { createEngineContext } from "../src/commands/fix-context.js";
 import { scopeIncludesManifestWrites } from "../src/commands/fix-scope.js";
+import { collectScanFileScope } from "../src/commands/scan-file-scope.js";
 import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { EngineContext } from "../src/engines/types.js";
 
@@ -15,6 +17,7 @@ const contextFor = (files?: string[]): EngineContext =>
 		languages: ["typescript"],
 		frameworks: [],
 		files: files?.map((name) => path.join(tmpDir, name)),
+		dependencyAuditFiles: files?.map((name) => path.join(tmpDir, name)),
 		installedTools: {},
 		config: {
 			quality: { maxFunctionLoc: 80, maxFileLoc: 400, maxNesting: 5, maxParams: 6 },
@@ -87,5 +90,43 @@ describe("manifest-only scopes keep project languages for dependency work", () =
 
 		expect(context.languages).toEqual([]);
 		expect(context.dependencyAuditLanguages).toEqual(["typescript"]);
+	});
+});
+
+// The hand-built contexts above cannot catch a mismatch between the shape this gate reads
+// and the shape the collector actually produces, so drive one case through the real thing.
+describe("scopeIncludesManifestWrites against a real collected scope", () => {
+	const git = (...args: string[]): void => {
+		spawnSync("git", args, { cwd: tmpDir, encoding: "utf-8" });
+	};
+
+	it("passes when a changed manifest and lockfile are the whole change", () => {
+		git("init");
+		git("config", "user.email", "test@example.com");
+		git("config", "user.name", "test");
+		fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "packages:\n");
+		fs.mkdirSync(path.join(tmpDir, "src"));
+		fs.writeFileSync(path.join(tmpDir, "src", "a.ts"), "export const a = 1;\n");
+		git("add", "-A");
+		git("commit", "-m", "init", "--no-verify");
+		fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"x"}');
+		fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "packages:\n  x: 1\n");
+
+		const scope = collectScanFileScope({
+			excludePatterns: [],
+			includePatterns: [],
+			mode: { kind: "changes" },
+			rootDirectory: tmpDir,
+		});
+		const context = createEngineContext(
+			tmpDir,
+			{ languages: ["typescript"], frameworks: [], installedTools: {} } as unknown as Parameters<
+				typeof createEngineContext
+			>[1],
+			DEFAULT_CONFIG,
+			{ scope },
+		);
+
+		expect(scopeIncludesManifestWrites(context)).toBe(true);
 	});
 });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getChangedFiles, getStagedFiles } from "../src/utils/git.js";
+import type { Diagnostic } from "../src/engines/types.js";
+import { classifyChangeContext, parseUnifiedDiffHunks } from "../src/utils/change-context.js";
+import { getChangedFiles, getChangedLineMap, getStagedFiles } from "../src/utils/git.js";
 
 const git = (cwd: string, args: string[]) => {
 	execFileSync("git", args, { cwd, stdio: "ignore" });
@@ -114,5 +116,82 @@ describe("getStagedFiles", () => {
 		expect(files).toContain(path.join(tmpDir, "staged.ts"));
 		expect(files).not.toContain(path.join(tmpDir, "base.ts"));
 		expect(files).not.toContain(path.join(tmpDir, "untracked.ts"));
+	});
+});
+
+const sampleDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+	filePath: "src/app.ts",
+	engine: "ai-slop",
+	rule: "ai-slop/unsafe-type-assertion",
+	severity: "warning",
+	message: "unsafe",
+	help: "",
+	line: 2,
+	column: 1,
+	category: "types",
+	fixable: false,
+	...overrides,
+});
+
+describe("changed-line hunk classification", () => {
+	it("classifies added and modified new-file lines, deleted-only hunks, and file-level findings", () => {
+		const diff = [
+			"diff --git a/src/app.ts b/src/app.ts",
+			"--- a/src/app.ts",
+			"+++ b/src/app.ts",
+			"@@ -1,1 +1,1 @@",
+			"-export const a = 1;",
+			"+export const a = 2;",
+			"@@ -10,2 +10,0 @@",
+			"-gone",
+			"-also",
+			"diff --git a/src/new.ts b/src/new.ts",
+			"new file mode 100644",
+			"--- /dev/null",
+			"+++ b/src/new.ts",
+			"@@ -0,0 +1,2 @@",
+			"+one",
+			"+two",
+		].join("\n");
+		const map = parseUnifiedDiffHunks(diff);
+		const root = "/repo";
+
+		expect(classifyChangeContext(sampleDiagnostic({ line: 1 }), map, root)).toBe("changed-line");
+		expect(classifyChangeContext(sampleDiagnostic({ line: 4 }), map, root)).toBe(
+			"existing-file-context",
+		);
+		expect(classifyChangeContext(sampleDiagnostic({ line: 0 }), map, root)).toBe("unknown");
+		expect(
+			classifyChangeContext(sampleDiagnostic({ filePath: "src/new.ts", line: 2 }), map, root),
+		).toBe("changed-line");
+		expect(
+			classifyChangeContext(sampleDiagnostic({ filePath: "src\\new.ts", line: 1 }), map, root),
+		).toBe("changed-line");
+	});
+
+	it("maps renamed files to the new path and treats untracked files as whole-file changes", () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-hunks-"));
+		try {
+			git(tmpDir, ["init"]);
+			git(tmpDir, ["config", "user.email", "test@example.com"]);
+			git(tmpDir, ["config", "user.name", "test"]);
+			git(tmpDir, ["config", "commit.gpgsign", "false"]);
+			write(tmpDir, "old.ts", "export const value = 1;\nexport const keep = 2;\n");
+			git(tmpDir, ["add", "old.ts"]);
+			git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+			git(tmpDir, ["mv", "old.ts", "renamed.ts"]);
+			write(tmpDir, "fresh.ts", "export const fresh = 1;\n");
+			const map = getChangedLineMap(tmpDir);
+			expect(map.get("renamed.ts")?.kind).toBe("hunks");
+			expect(map.get("fresh.ts")).toEqual({ kind: "all" });
+			expect(
+				classifyChangeContext(sampleDiagnostic({ filePath: "renamed.ts", line: 1 }), map, tmpDir),
+			).toBe("existing-file-context");
+			expect(
+				classifyChangeContext(sampleDiagnostic({ filePath: "fresh.ts", line: 1 }), map, tmpDir),
+			).toBe("changed-line");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -169,6 +169,30 @@ describe("changed-line hunk classification", () => {
 		).toBe("changed-line");
 	});
 
+	it("parses hunks when the user has git colour forced on", () => {
+		// color.ui=always puts ANSI escapes ahead of the +++ and @@ markers, which hides
+		// every file and range from the hunk parser.
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-color-"));
+		try {
+			git(tmpDir, ["init"]);
+			git(tmpDir, ["config", "user.email", "test@example.com"]);
+			git(tmpDir, ["config", "user.name", "test"]);
+			git(tmpDir, ["config", "commit.gpgsign", "false"]);
+			git(tmpDir, ["config", "color.ui", "always"]);
+			git(tmpDir, ["config", "color.diff", "always"]);
+			write(tmpDir, "app.ts", "export const a = 1;\nexport const b = 2;\n");
+			git(tmpDir, ["add", "app.ts"]);
+			git(tmpDir, ["commit", "-m", "init", "--no-verify"]);
+			write(tmpDir, "app.ts", "export const a = 1;\nexport const b = 3;\n");
+
+			const map = getChangedLineMap(tmpDir);
+
+			expect(map.get("app.ts")?.kind).toBe("hunks");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("maps renamed files to the new path and treats untracked files as whole-file changes", () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-git-hunks-"));
 		try {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -169,6 +169,26 @@ describe("changed-line hunk classification", () => {
 		).toBe("changed-line");
 	});
 
+	it("does not treat added content that looks like a header as a new file", () => {
+		// With -U0 an added line is written "+<content>", so content starting with "++ "
+		// reproduces a "+++ " header and used to hijack the current file.
+		const diff = [
+			"diff --git a/src/real.ts b/src/real.ts",
+			"--- a/src/real.ts",
+			"+++ b/src/real.ts",
+			"@@ -1,0 +2,2 @@",
+			"++ not a header, just content",
+			"+++ b/src/phantom.ts",
+			"@@ -10,0 +11,1 @@",
+			"+const after = 1;",
+		].join("\n");
+
+		const map = parseUnifiedDiffHunks(diff);
+
+		expect(map.has("src/phantom.ts")).toBe(false);
+		expect(map.get("src/real.ts")?.kind).toBe("hunks");
+	});
+
 	it("parses hunks when the user has git colour forced on", () => {
 		// color.ui=always puts ANSI escapes ahead of the +++ and @@ markers, which hides
 		// every file and range from the hunk parser.

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -45,4 +45,37 @@ describe("terminal rendering", () => {
 		expect(output).toContain("src/example-4.ts:4:1");
 		expect(output).not.toContain("more location(s)");
 	});
+
+	it("lists changed-line findings before existing-file-context and still shows all in verbose mode", () => {
+		const output = renderDiagnostics(
+			[
+				createDiagnostic({
+					filePath: "src/old.ts",
+					line: 4,
+					message: "existing finding",
+					changeContext: "existing-file-context",
+				}),
+				createDiagnostic({
+					filePath: "src/new.ts",
+					line: 1,
+					message: "new finding",
+					changeContext: "changed-line",
+				}),
+				createDiagnostic({
+					filePath: "src/file.ts",
+					line: 0,
+					message: "file-level finding",
+					changeContext: "unknown",
+				}),
+			],
+			true,
+		);
+
+		expect(output).toContain("Changed lines");
+		expect(output).toContain("Existing file context");
+		expect(output).toContain("Unclassified");
+		expect(output.indexOf("Changed lines")).toBeLessThan(output.indexOf("Existing file context"));
+		expect(output.indexOf("new finding")).toBeLessThan(output.indexOf("existing finding"));
+		expect(output).toContain("file-level finding");
+	});
 });

--- a/tests/output/json.test.ts
+++ b/tests/output/json.test.ts
@@ -75,6 +75,28 @@ describe("json output", () => {
 		expect(out.findingAssessment.byKind["confirmed-defect"]).toBe(1);
 	});
 
+	it("exposes stable changeContext metadata when present", () => {
+		const out = buildJsonOutput(
+			[result([diagnostic({ changeContext: "changed-line" })])],
+			{ score: 50, label: "Critical" },
+			10,
+			10,
+			scoreable,
+		);
+		expect(out.diagnostics[0].changeContext).toBe("changed-line");
+	});
+
+	it("omits changeContext when the scan did not classify diffs", () => {
+		const out = buildJsonOutput(
+			[result([diagnostic()])],
+			{ score: 50, label: "Critical" },
+			10,
+			10,
+			scoreable,
+		);
+		expect(out.diagnostics[0].changeContext).toBeUndefined();
+	});
+
 	it("includes advisory score impact metadata for soft config warnings", () => {
 		const out = buildJsonOutput(
 			[

--- a/tests/output/sarif.test.ts
+++ b/tests/output/sarif.test.ts
@@ -62,6 +62,20 @@ describe("buildSarifLog", () => {
 		expect(log.runs[0]?.results[2]?.ruleIndex).toBe(1);
 	});
 
+	it("exposes changeContext on result properties when classified", () => {
+		const log = buildSarifLog([
+			createResult([createDiagnostic({ changeContext: "existing-file-context" })]),
+		]);
+		expect(log.runs[0]?.results[0]?.properties).toEqual({
+			changeContext: "existing-file-context",
+		});
+	});
+
+	it("omits result properties when changeContext is absent", () => {
+		const log = buildSarifLog([createResult([createDiagnostic()])]);
+		expect(log.runs[0]?.results[0]?.properties).toBeUndefined();
+	});
+
 	it("emits a 1-based physical location", () => {
 		const log = buildSarifLog([
 			createResult([createDiagnostic({ filePath: "src/a/b.ts", line: 0, column: 0 })]),

--- a/tests/ui/agent-tui/sidebar.test.tsx
+++ b/tests/ui/agent-tui/sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "ink-testing-library";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionState } from "../../../src/agents/session-state.js";
 import { Sidebar } from "../../../src/ui/agent-tui/Sidebar.js";
 
@@ -17,6 +17,26 @@ describe("Sidebar", () => {
 		expect(frame).toContain("24");
 		expect(frame).toContain("Score");
 		expect(frame).not.toContain("$");
+	});
+
+	it("renders elapsed without reading the clock during render", () => {
+		// Date.now() in the render body is impure, and with nothing driving a re-render it
+		// also left the value stale until an unrelated update happened.
+		const store = createSessionState({
+			provider: "Mystery",
+			providerSource: "auto",
+			targetScore: 90,
+			targetRepo: "/r",
+		});
+		const nowSpy = vi.spyOn(Date, "now");
+
+		try {
+			const { lastFrame } = render(<Sidebar state={store.getState()} />);
+
+			expect(lastFrame() ?? "").toContain("Elapsed");
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	it("shows cost when the provider model is known", () => {


### PR DESCRIPTION
`fix` and `scan` can now be pointed at what changed rather than the whole tree, and `fix` can show its plan before writing anything.

**No scoring change in this release.** Unlike 0.15.0, existing badges and CI thresholds are unaffected.

## Added

| flag | effect |
| --- | --- |
| `fix --dry-run` | prints planned and skipped steps, writes nothing |
| `fix --changes` | limits fixes to changed files |
| `fix --staged` | limits fixes to staged files |
| `fix --base <ref>` | diff base for `--changes`, defaults to `HEAD` |

Findings are also classified as changed-line or existing-file context, so a scoped run separates what a change introduced from what it merely sits beside. Visible in terminal, JSON and SARIF.

## Fixed

All five came from the Codex review on the three feature PRs, and all were fixed before merge rather than deferred:

- **P1: dependency fixes escaped the selected scope.** A scope holding a lockfile and a source file, but not `package.json`, still ran the unused-dependency fixer, which always rewrites `package.json`. Force audit and Expo alignment shared the gap. The gate now asks whether every file the fixer writes is in scope.
- Dependency-only scopes detected no language, so selecting just a manifest skipped every dependency fixer.
- The dotnet format report was written into the project root and deleted on every run, destroying a user-owned `.aislop-dotnet-format.json`. Moved outside the tree, which fixes the non-preview path too.
- C#/C++ formatters were missing from the dry-run plan.
- Changed-line detection broke under `color.ui=always`, silently marking every finding as unknown context.

## Also in this promotion

Six dependency bumps: biome 2.5.10, vitest 4.1.11, @types/node 26.4.0, expo-doctor 1.20.3, and both codeql-action halves to 4.37.9.

## Verification

- `--version` reports 0.16.0
- typecheck clean, **2098 tests**, self-scan **100/100**
- `npm pack --dry-run` produces `aislop-0.16.0.tgz`, 32 files, with the three assets that can silently drop from the `files` field all present

## After merge

Cut the draft release for `v0.16.0`. The workflow fires on `release: published`, so nothing reaches npm until you publish. PyPI and Homebrew follow the same two-phase and formula-bump path as last time.
