### PR TITLE
fix(scope): read the manifest gate from the audit file list

### DIFF
--- a/src/commands/fix-scope.ts
+++ b/src/commands/fix-scope.ts
@@ -66,8 +66,10 @@ const WRITTEN_LOCKFILES = [
 
 export const scopeIncludesManifestWrites = (context: EngineContext): boolean => {
 	if (!isScopedFix(context)) return true;
+	// Manifests and lockfiles are collected separately: context.files holds only source
+	// extensions, so package.json is never in it and reading it here always says no.
 	const selected = new Set(
-		(context.files ?? []).map((candidate) =>
+		(context.dependencyAuditFiles ?? []).map((candidate) =>
 			projectRelativePosix(context.rootDirectory, candidate),
 		),
 	);

--- a/tests/fix-scope-manifest.test.ts
+++ b/tests/fix-scope-manifest.test.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
 import { createEngineContext } from "../src/commands/fix-context.js";
 import { scopeIncludesManifestWrites } from "../src/commands/fix-scope.js";
+import { collectScanFileScope } from "../src/commands/scan-file-scope.js";
 import { DEFAULT_CONFIG } from "../src/config/defaults.js";
 import type { EngineContext } from "../src/engines/types.js";
 
@@ -15,6 +17,7 @@ const contextFor = (files?: string[]): EngineContext =>
 		languages: ["typescript"],
 		frameworks: [],
 		files: files?.map((name) => path.join(tmpDir, name)),
+		dependencyAuditFiles: files?.map((name) => path.join(tmpDir, name)),
 		installedTools: {},
 		config: {
 			quality: { maxFunctionLoc: 80, maxFileLoc: 400, maxNesting: 5, maxParams: 6 },
@@ -87,5 +90,43 @@ describe("manifest-only scopes keep project languages for dependency work", () =
 
 		expect(context.languages).toEqual([]);
 		expect(context.dependencyAuditLanguages).toEqual(["typescript"]);
+	});
+});
+
+// The hand-built contexts above cannot catch a mismatch between the shape this gate reads
+// and the shape the collector actually produces, so drive one case through the real thing.
+describe("scopeIncludesManifestWrites against a real collected scope", () => {
+	const git = (...args: string[]): void => {
+		spawnSync("git", args, { cwd: tmpDir, encoding: "utf-8" });
+	};
+
+	it("passes when a changed manifest and lockfile are the whole change", () => {
+		git("init");
+		git("config", "user.email", "test@example.com");
+		git("config", "user.name", "test");
+		fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "packages:\n");
+		fs.mkdirSync(path.join(tmpDir, "src"));
+		fs.writeFileSync(path.join(tmpDir, "src", "a.ts"), "export const a = 1;\n");
+		git("add", "-A");
+		git("commit", "-m", "init", "--no-verify");
+		fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"x"}');
+		fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "packages:\n  x: 1\n");
+
+		const scope = collectScanFileScope({
+			excludePatterns: [],
+			includePatterns: [],
+			mode: { kind: "changes" },
+			rootDirectory: tmpDir,
+		});
+		const context = createEngineContext(
+			tmpDir,
+			{ languages: ["typescript"], frameworks: [], installedTools: {} } as unknown as Parameters<
+				typeof createEngineContext
+			>[1],
+			DEFAULT_CONFIG,
+			{ scope },
+		);
+
+		expect(scopeIncludesManifestWrites(context)).toBe(true);
 	});
 });


### PR DESCRIPTION
Regression found reviewing #377, introduced by the scope gate added in #374.

`scopeIncludesManifestWrites` looked for `package.json` in `context.files`. The collector only puts source extensions there; manifests and lockfiles go to `dependencyAuditFiles`. So the gate answered no on every scoped run.

Effect: `fix --changes` and `fix --staged` silently skipped **Unused dependencies**, **Dependency audit fixes** and **Expo dependency alignment**, even when the manifest was the entire change. It also made the `dependencyAuditLanguages` work shipped in the same PR unreachable.

## Reproduced against the built CLI

With `package.json`, `pnpm-lock.yaml` and a source file all modified:

```
Scope  1 changed file(s)
- Unused dependencies - no manifest or lockfile in the selected scope
```

After the fix, same repo:

```
Scope  1 changed file(s)
* Unused dependencies - 0 findings
```

And the case the gate exists for, a lockfile changed without `package.json`, is still refused.

## Why the tests missed it

The existing test hand-built a scope with `package.json` inside `files`, a shape `collectScanFileScope` never produces, so it validated the predicate against an input that cannot occur. Added a case that drives a real git repo through the collector. Reverting only the source change makes it fail, so it genuinely covers the regression.

## Verification

typecheck clean, 2099 tests, self-scan 100/100.