### PR TITLE
fix(scope): align scoped fix with scan, and harden diff parsing

### DIFF
--- a/src/commands/fix-context.ts
+++ b/src/commands/fix-context.ts
@@ -27,7 +27,9 @@ export const createEngineContext = (
 	config: { quality: config.quality, security: config.security, lint: config.lint },
 	...(options.scope
 		? {
-				files: [...new Set([...options.scope.files, ...options.scope.testFiles])],
+				// Kept apart the way scan does it: merging them made scoped fixers rewrite test
+				// files that an unscoped fix never touches.
+				files: options.scope.files,
 				testFiles: options.scope.testFiles,
 				projectFiles: options.scope.projectFiles,
 				dependencyAuditFiles: options.scope.dependencyAuditFiles,

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -106,6 +106,13 @@ export const fixCommand = async (
 		});
 	}
 
+	if (options.dryRun && (options.agent || options.prompt)) {
+		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
+			log.error("--dry-run cannot be combined with an agent handoff or --prompt.");
+			return { exitCode: 1 };
+		});
+	}
+
 	const scopeError = fixScopeError(resolvedDir, options);
 	if (scopeError) {
 		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
@@ -220,7 +227,8 @@ const runFixBody = async (
 		);
 	}
 	const steps: FixStepResult[] = [];
-	const rail = new LiveRail(process.env.CI === "1" ? { tty: false } : {});
+	const isCi = process.env.CI === "true" || process.env.CI === "1";
+	const rail = new LiveRail(isCi ? { tty: false } : {});
 
 	const runStep = async (
 		name: string,
@@ -310,7 +318,7 @@ const runFixBody = async (
 		allDiagnostics,
 		config.scoring.weights,
 		config.scoring.thresholds,
-		scope ? scope.files.length + scope.testFiles.length : projectInfo.sourceFileCount,
+		scope ? scope.scoreFileCount : projectInfo.sourceFileCount,
 		config.scoring.smoothing,
 		config.scoring.maxPerRule,
 	);

--- a/src/utils/change-context.ts
+++ b/src/utils/change-context.ts
@@ -22,17 +22,27 @@ const parseHunkRange = (
 	return { start, end: start + count - 1 };
 };
 
+// git writes "+++ a/path", "+++ b/path" or "+++ /dev/null"; a bare "+++ " is content.
+const FILE_HEADER_RE = /^\+\+\+ (?:[ab]\/|\/dev\/null$)/;
+
 export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> => {
 	const byFile = new Map<string, { start: number; end: number }[]>();
 	let current: string | null = null;
 
+	// Inside a hunk body an added line is written "+<content>", so content beginning with
+	// "++ " reproduces a "+++ " header. Only trust the header before the first hunk.
+	let inHunkBody = false;
+
 	for (const raw of diff.split(/\r?\n/)) {
+		if (raw.startsWith("diff --git ") || raw.startsWith("rename to ")) {
+			inHunkBody = false;
+		}
 		if (raw.startsWith("rename to ")) {
 			current = toPosix(raw.slice("rename to ".length).trim());
 			if (current && !byFile.has(current)) byFile.set(current, []);
 			continue;
 		}
-		if (raw.startsWith("+++ ")) {
+		if (!inHunkBody && FILE_HEADER_RE.test(raw)) {
 			const name = stripDiffPrefix(raw.slice(4).trim());
 			current = name === "/dev/null" ? null : toPosix(name);
 			if (current && !byFile.has(current)) byFile.set(current, []);
@@ -40,7 +50,10 @@ export const parseUnifiedDiffHunks = (diff: string): Map<string, ChangedLines> =
 		}
 		if (!current) continue;
 		const match = HUNK_RE.exec(raw);
-		if (!match) continue;
+		if (!match) {
+			continue;
+		}
+		inHunkBody = true;
 		const range = parseHunkRange(match[3], match[4]);
 		if (!range) continue;
 		const ranges = byFile.get(current);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -17,11 +17,15 @@ export const baseRefExists = (cwd: string, ref: string): boolean => {
 
 export const getChangedFiles = (cwd: string, base?: string): string[] => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const diff = spawnSync(
+		"git",
+		["diff", "--no-color", "--name-only", "--diff-filter=ACMR", baseRef],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	if (diff.error || diff.status !== 0) return [];
 
 	const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
@@ -44,11 +48,15 @@ export const getChangedFiles = (cwd: string, base?: string): string[] => {
 };
 
 export const getStagedFiles = (cwd: string): string[] => {
-	const result = spawnSync("git", ["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const result = spawnSync(
+		"git",
+		["diff", "--no-color", "--cached", "--name-only", "--diff-filter=ACMR"],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	if (result.error || result.status !== 0) return [];
 	return result.stdout
 		.split("\n")
@@ -68,11 +76,15 @@ const listUntrackedFiles = (cwd: string): string[] => {
 
 export const getChangedLineMap = (cwd: string, base?: string): Map<string, ChangedLines> => {
 	const baseRef = base ?? "HEAD";
-	const diff = spawnSync("git", ["diff", "--no-color", "-U0", "--diff-filter=ACMR", baseRef], {
-		cwd,
-		encoding: "utf-8",
-		maxBuffer: MAX_BUFFER,
-	});
+	const diff = spawnSync(
+		"git",
+		["diff", "--no-color", "--no-ext-diff", "-U0", "--diff-filter=ACMR", baseRef],
+		{
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: MAX_BUFFER,
+		},
+	);
 	const map = !diff.error && diff.status === 0 ? parseUnifiedDiffHunks(diff.stdout) : new Map();
 	for (const name of listUntrackedFiles(cwd)) {
 		map.set(projectRelativePosix(cwd, path.resolve(cwd, name)), { kind: "all" });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -169,6 +169,26 @@ describe("changed-line hunk classification", () => {
 		).toBe("changed-line");
 	});
 
+	it("does not treat added content that looks like a header as a new file", () => {
+		// With -U0 an added line is written "+<content>", so content starting with "++ "
+		// reproduces a "+++ " header and used to hijack the current file.
+		const diff = [
+			"diff --git a/src/real.ts b/src/real.ts",
+			"--- a/src/real.ts",
+			"+++ b/src/real.ts",
+			"@@ -1,0 +2,2 @@",
+			"++ not a header, just content",
+			"+++ b/src/phantom.ts",
+			"@@ -10,0 +11,1 @@",
+			"+const after = 1;",
+		].join("\n");
+
+		const map = parseUnifiedDiffHunks(diff);
+
+		expect(map.has("src/phantom.ts")).toBe(false);
+		expect(map.get("src/real.ts")?.kind).toBe("hunks");
+	});
+
 	it("parses hunks when the user has git colour forced on", () => {
 		// color.ui=always puts ANSI escapes ahead of the +++ and @@ markers, which hides
 		// every file and range from the hunk parser.


### PR DESCRIPTION
The six remaining findings from the review of the v0.16.0 promotion. Each was reproduced before fixing.

## Scoped fix rewrote test files

`createEngineContext` merged `scope.testFiles` into `files`, and `filterExplicitFiles` does not drop tests the way `filterProjectFiles` does. Verified against the built CLI on a repo with a changed test file:

```
aislop fix            -> untouched
aislop fix --changes  -> MODIFIED
```

`files` now carries source only, matching how `scan` builds its context. Same repo now reports `untouched` for both.

## Scoped fix and scan disagreed on the score

`scan` passes `scoreFileCount` (whole project); the fix path passed the selection size. Since 0.15.0 scores finding density per file, a one-file change in a 41-file repo gave:

```
scan --changes: 98 / 100
fix  --changes: 89 / 100   (before)
fix  --changes: 98 / 100   (after)
```

This is also what the release note meant by no scoring change, so it now holds for the scoped path too.

## `--dry-run` silently swallowed an agent handoff

`finishDryRun` returned before the agent and prompt branches, so `fix --dry-run --claude` printed a plan and exited 0 without launching anything. Now rejected up front like the other conflicting flags, exit code 1.

## Diff header parsing could be hijacked

`parseUnifiedDiffHunks` accepted any line opening `+++ `. Under `-U0` an added line whose content begins `++ ` reproduces exactly that, so a phantom path captured every following hunk and the real findings fell back to unclassified. Headers are now matched against `a/`, `b/` or `/dev/null`, and only outside a hunk body. The added test fails against the previous parser.

## External differ emptied the line map

`getChangedLineMap` now passes `--no-ext-diff`. A configured `diff.external` produced non-unified output and silently marked every finding unknown, the same failure class as the `color.ui=always` bug fixed earlier in this release.

## CI probe missed `CI=true`

`fix` checked only `CI === "1"`, while `scan-engine-runner`, `telemetry/client` and `telemetry/env` all check both. On Actions, GitLab and CircleCI the spinner escapes reached the logs.

## Verification

typecheck clean, **2100 tests**, self-scan **100/100**. The two behavioural fixes were confirmed against the built CLI rather than tests alone, and the two new tests were checked to fail against the pre-fix code.