### PR TITLE
fix: prune target build directories

### DIFF
--- a/src/utils/source-file-policy.ts
+++ b/src/utils/source-file-policy.ts
@@ -109,6 +109,7 @@ export const WALK_PRUNE_DIRECTORIES = new Set([
 	"dist",
 	"build",
 	"out",
+	"target",
 	"coverage",
 	"vendor",
 	"vendors",

--- a/tests/project-file-list.test.ts
+++ b/tests/project-file-list.test.ts
@@ -7,6 +7,10 @@ import {
 	enumerateProjectFiles,
 	enumerateProjectFilesFromDisk,
 } from "../src/utils/project-file-list.js";
+import {
+	listProjectFiles,
+	listProjectFilesFromDisk,
+} from "../src/utils/source-file-selection.js";
 
 const writeFile = (rootDirectory: string, relativePath: string): void => {
 	const filePath = path.join(rootDirectory, relativePath);
@@ -38,6 +42,19 @@ describe("project file enumeration", () => {
 		expect(enumerateProjectFiles(rootDirectory, new Set(["dist", "vendor"]))).toEqual([
 			"src/app.ts",
 		]);
+	});
+
+	it("prunes target build directories from default enumeration", () => {
+		execFileSync("git", ["init"], { cwd: rootDirectory, stdio: "ignore" });
+		writeFile(rootDirectory, "src/app.ts");
+		writeFile(rootDirectory, "target/debug/generated.rs");
+		execFileSync("git", ["add", "-f", "src/app.ts", "target/debug/generated.rs"], {
+			cwd: rootDirectory,
+			stdio: "ignore",
+		});
+
+		expect(listProjectFiles(rootDirectory)).toEqual(["src/app.ts"]);
+		expect(listProjectFilesFromDisk(rootDirectory)).toEqual(["src/app.ts"]);
 	});
 
 	it("does not follow directory symlinks or junctions during disk enumeration", () => {


### PR DESCRIPTION
## What does this PR do?

Prunes `target` directories before project file enumeration descends into them. Rust and Maven build outputs can contain tens of thousands of files, and automatic hooks enumerate the project from disk before applying configured exclude patterns.

On an antiburn checkout with about 130,000 files across 55 GB of Rust build output, `aislop hook claude` fell from about 40 seconds to 0.8 seconds.

The regression test covers both Git-backed and direct disk enumeration.

## Type of change

- [x] Bug fix (fixes an issue without changing behavior)
- [ ] New rule (adds a new detection rule)
- [ ] New feature (adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (2,112 tests)
- [x] `pnpm build && node dist/cli.js scan .` scores Healthy
- [x] New rules have positive AND negative test cases (not applicable)
- [x] New rules are registered in `src/commands/rules.ts` (not applicable)
- [x] Self-detection patterns use string concatenation (not applicable)

## Related issues

No related issue.